### PR TITLE
Properly close Kafka Producers and Consumers

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     privileged: true
 
     volumes:
-      - ..:/workspace:cached
+      - .:/workspace:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     privileged: true
 
     volumes:
-      - .:/workspace:cached
+      - ..:/workspace:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity

--- a/examples/stream_calc/container.py
+++ b/examples/stream_calc/container.py
@@ -40,8 +40,8 @@ class Container(containers.DeclarativeContainer):
     config = providers.Configuration()
 
     # outbound providers:
-    event_publisher = providers.Factory[EventPublisherProtocol](
-        KafkaEventPublisher,
+    event_publisher = providers.Resource[EventPublisherProtocol](
+        KafkaEventPublisher.as_resource,
         service_name=config.service_name,
         client_suffix=config.client_suffix,
         kafka_servers=config.kafka_servers,
@@ -63,8 +63,8 @@ class Container(containers.DeclarativeContainer):
     )
 
     # inbound providers:
-    event_subscriber = providers.Factory[KafkaEventSubscriber](
-        KafkaEventSubscriber,
+    event_subscriber = providers.Resource[KafkaEventSubscriber](
+        KafkaEventSubscriber.as_resource,
         service_name=config.service_name,
         client_suffix=config.client_suffix,
         kafka_servers=config.kafka_servers,

--- a/examples/stream_calc/main.py
+++ b/examples/stream_calc/main.py
@@ -32,4 +32,8 @@ def run() -> None:
     logging.basicConfig(level=config.log_level)
 
     event_subscriber = container.event_subscriber()
-    event_subscriber.run()
+
+    try:
+        event_subscriber.run()
+    finally:
+        container.shutdown_resources()

--- a/examples/stream_calc/translators/eventsub.py
+++ b/examples/stream_calc/translators/eventsub.py
@@ -68,7 +68,7 @@ class EventProblemReceiver(EventSubscriberProtocol):
             self._check_payload(
                 payload, expected_fields=["problem_id", "dividend", "divisor"]
             )
-            self._problem_receiver.devide(
+            self._problem_receiver.divide(
                 problem_id=payload["problem_id"],
                 dividend=payload["dividend"],
                 divisor=payload["divisor"],

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -19,6 +19,7 @@
 import json
 from unittest.mock import Mock
 
+import pytest
 from kafka import KafkaConsumer, KafkaProducer
 from testcontainers.kafka import KafkaContainer
 
@@ -35,20 +36,24 @@ def test_kafka_event_publisher():
 
     with KafkaContainer() as kafka:
 
-        # publish event using the provider:
-        event_publisher = KafkaEventPublisher(
+        as_resource = KafkaEventPublisher.as_resource(
             service_name="test_publisher",
             client_suffix="1",
             kafka_servers=[kafka.get_bootstrap_server()],
         )
 
-        with event_publisher:
+        # publish event using the provider:
+        event_publisher = next(as_resource)
+        try:
             event_publisher.publish(
                 payload=payload,
                 type_=type_,
                 key=key,
                 topic=topic,
             )
+        finally:
+            with pytest.raises(StopIteration):
+                next(as_resource)
 
         # consume event using the python-kafka library directly:
         consumer = KafkaConsumer(
@@ -104,18 +109,22 @@ def test_kafka_event_subscriber():
             producer.close()
 
         # setup the provider:
-        event_subscriber = KafkaEventSubscriber(
+        as_resource = KafkaEventSubscriber.as_resource(
             service_name="event_subscriber",
             client_suffix="1",
             kafka_servers=[kafka.get_bootstrap_server()],
             translator=translator,
         )
 
-        with event_subscriber:
+        event_subscriber = next(as_resource)
+        try:
             # consume one event:
             exec_with_timeout(
                 lambda: event_subscriber.run(forever=False), timeout_after=2
             )
+        finally:
+            with pytest.raises(StopIteration):
+                next(as_resource)
 
         # check if the translator was called correctly:
         translator.consume.assert_called_once_with(

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -86,7 +86,7 @@ def test_kafka_event_publisher(
         assert callable(pc_kwargs["value_serializer"])
 
         # publish one event:
-        with (pytest.raises(exception) if exception else nullcontext()):
+        with (pytest.raises(exception) if exception else nullcontext()):  # type: ignore
             event_publisher.publish(
                 payload=payload,
                 type_=type_,
@@ -190,7 +190,7 @@ def test_kafka_event_subscriber(
     event_subscriber = next(as_resource)
     try:
         # consume one event:
-        with (pytest.raises(exception) if exception else nullcontext()):
+        with (pytest.raises(exception) if exception else nullcontext()):  # type: ignore
             event_subscriber.run(forever=False)
     finally:
         with pytest.raises(StopIteration):

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -17,8 +17,8 @@
 """Testing Apache Kafka based providers."""
 
 from contextlib import nullcontext
+from typing import Optional
 from unittest.mock import MagicMock, Mock
-from typing import Type, Optional
 
 import pytest
 
@@ -84,7 +84,7 @@ def test_kafka_event_publisher(
         assert pc_kwargs["bootstrap_servers"] == ["my-fake-kafka-server"]
         assert callable(pc_kwargs["key_serializer"])
         assert callable(pc_kwargs["value_serializer"])
-        
+
         # publish one event:
         with (pytest.raises(exception) if exception else nullcontext()):
             event_publisher.publish(
@@ -198,7 +198,6 @@ def test_kafka_event_subscriber(
 
     # check if consumer was closed correctly:
     consumer.close.assert_called_once()
-
 
     # check if the translator was called correctly:
     if is_translator_called:


### PR DESCRIPTION
On my machine, the integration tests crash at the end with the following error message:

```
tests/integration/test_akafka.py::test_kafka_event_subscriber
/home/vscode/.local/lib/python3.9/site-packages/_pytest/unraisableexception.py:78: PytestUnraisableExceptionWarning: Exception ignored in: <function ConsumerCoordinator._del_ at ...>
```

This seems to happen because the garbage collector kicks in and the Kafka consumer is not closed.

So we should make sure that consumers and producers are always closed in the implementation fo the providers and when used directly in the integration tests.
