### PR TITLE
utilities for async dependency injection (GDEV-845)

### DIFF
--- a/hexkit/custom_types.py
+++ b/hexkit/custom_types.py
@@ -28,9 +28,9 @@ JsonObject = Mapping[str, Union[int, float, str, bool, list[Any], Mapping[str, A
 Ascii = str
 
 
-# A ContextConstructable is a class with a classmethod that is an async context manager
-# for safely setting up and tearing down an instance of that class.
-# With the current typing features of python, it seems not possible to correctly type
+# A ContextConstructable is a class with a classmethod `construct` that creates an async
+# context manager for safely setting up and tearing down an instance of that class.
+# With the current typing features of Python, it seems not possible to correctly type
 # a class with that signature.
 # E.g. one could define a typing.Protocol subclass with following method:
 # ```
@@ -39,7 +39,7 @@ Ascii = str
 #     @asynccontextmanager
 #     def construct(cls, *args: Any, **kwargs: Any): ...
 # ```
-# However, this is incompartible with implementations that don't explicitly use `*args`
+# However, this is incompatible with implementations that don't explicitly use `*args`
 # and `*kwargs`, e.g. the following method does not comply with the above function stub:
 # ```
 # class SomeImplementation:

--- a/hexkit/custom_types.py
+++ b/hexkit/custom_types.py
@@ -26,3 +26,26 @@ JsonObject = Mapping[str, Union[int, float, str, bool, list[Any], Mapping[str, A
 # A type indicating that a string should be ascii-compatible.
 # Technically it is an alias for `str` so it only serves documention purposes.
 Ascii = str
+
+
+# A ContextConstructable is a class with a classmethod that is an async context manager
+# for safely setting up and tearing down an instance of that class.
+# With the current typing features of python, it seems not possible to correctly type
+# a class with that signature.
+# E.g. one could define a typing.Protocol subclass with following method:
+# ```
+# class ContextConstructable(Protocol):
+#     @classmethod
+#     @asynccontextmanager
+#     def construct(cls, *args: Any, **kwargs: Any): ...
+# ```
+# However, this is incompartible with implementations that don't explicitly use `*args`
+# and `*kwargs`, e.g. the following method does not comply with the above function stub:
+# ```
+# class SomeImplementation:
+#     @classmethod
+#     @asynccontextmanager
+#     def construct(cls, foo: str): ...
+# ```
+# Thus using a type alias for now:
+ContextConstructable = Any

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -32,6 +32,14 @@ import dependency_injector.providers
 
 from hexkit.custom_types import ContextConstructable
 
+__all__ = [
+    "get_constructor",
+    "ContainerBase",
+    "NotConstructableError",
+    "ContextConstructor",
+    "AsyncInitShutdownError",
+]
+
 
 class NotConstructableError(TypeError):
     """Thrown when a ContextConstructable expected but not obtained."""

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -1,0 +1,80 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Utilities for dependency injection based on the dependency_injector framework."""
+
+from typing import Any, AsyncContextManager, AsyncIterator, Callable, Optional
+
+import dependency_injector.providers
+import dependency_injector.resources
+
+from hexkit.custom_types import ContextConstructable
+
+
+class ContextConstructor(dependency_injector.providers.Resource):
+    """Maps an asynchronous context manager onto the Resource class from the
+    `dependency_injector` framework."""
+
+    @staticmethod
+    def constructable_to_resource(
+        constructable: type[ContextConstructable],
+    ) -> Callable[..., AsyncIterator[Any]]:
+        """
+        Converts an async context manager to an async Generator that is compatible
+        with Resource definition of the `dependency_injector` framework.
+        """
+
+        if not (
+            hasattr(constructable, "construct")
+            # Using isinstance together with Callable should be supported,
+            # see: https://peps.python.org/pep-0484/#callable
+            # Thus ignoring mypy error:
+            and isinstance(constructable.construct, Callable)  # type: ignore
+        ):
+            raise TypeError(
+                "ContextConstructable class must have a callable `construct` attribute."
+            )
+
+        async def resource(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+            constructor = constructable.construct(*args, **kwargs)
+
+            if not isinstance(constructor, AsyncContextManager):
+                raise TypeError(
+                    "Callable attribute `construct` of ContextConstructable class must"
+                    + " return an async context manager."
+                )
+
+            async with constructor as context:
+                yield context
+
+        return resource
+
+    # This pylint error is inherited from the dependency_injector framework, other
+    # DI providers use the same basic signitature:
+    # pylint: disable=keyword-arg-before-vararg
+    def __init__(
+        self,
+        provides: Optional[type[ContextConstructable]] = None,
+        *args: dependency_injector.providers.Injection,
+        **kwargs: dependency_injector.providers.Injection
+    ):
+        """Initialize `dependency_injector`'s Resource with an AsyncContextManager."""
+
+        if provides is None:
+            super().__init__()
+        else:
+            resource = self.constructable_to_resource(provides)
+            super().__init__(resource, *args, **kwargs)

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -15,7 +15,9 @@
 #
 
 """
-Utilities for dependency injection based on the dependency_injector framework.
+This module contains a helper function that automatically selects the suitable
+"Provider" class for the dependency_injector framework and makes the "Container" class
+usable as async context manager.
 
 Please Note:
 To avoid overloading the "Provider" terminology of the Triple Hexagonal Architecture

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -71,8 +71,8 @@ class ContextConstructor(dependency_injector.providers.Resource):
         constructable: type[ContextConstructable],
     ) -> Callable[..., AsyncIterator[Any]]:
         """
-        Converts an async context manager to an async Generator that is compatible
-        with Resource definition of the `dependency_injector` framework.
+        Converts an async context manager to an async generator that is compatible
+        with the Resource definition of the `dependency_injector` framework.
         """
 
         assert_context_constructable(constructable)

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -169,7 +169,7 @@ class ContainerBase(dependency_injector.containers.DeclarativeContainer):
     instance_type = CMDynamicContainer
 
     # Stubs to convince type checkers that this object is an async context manager,
-    # event though the corresponding logic is only implemented in self.instance_type:
+    # even though the corresponding logic is only implemented in self.instance_type:
     # (See the implementation of the dependency_injector.containers.DeclarativeContainer
     # for more details.)
 

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -44,11 +44,10 @@ class AsyncInitShutdownError(TypeError):
 
 def assert_context_constructable(constructable: type[ContextConstructable]):
     """
-    Makes sure that the provided object has a callable attribute `construct` attribute.
+    Make sure that the provided object has a callable attribute `construct`.
     If this check passes, it can be seen as a strong indication that the provided object
-    is compliant with our definition of a ContextConstructable.
-    However, it does not checked whether the callable `construct` method returns an
-    async context manager.
+    is compliant with our definition of a ContextConstructable. However, it does not
+    check whether `construct` really returns an async context manager.
     """
 
     if not (

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -50,13 +50,7 @@ def assert_context_constructable(constructable: type[ContextConstructable]):
     check whether `construct` really returns an async context manager.
     """
 
-    if not (
-        hasattr(constructable, "construct")
-        # Using isinstance together with Callable should be supported,
-        # see: https://peps.python.org/pep-0484/#callable
-        # Thus ignoring mypy error:
-        and isinstance(constructable.construct, Callable)  # type: ignore
-    ):
+    if not callable(getattr(constructable, "construct", None)):
         raise NotConstructableError(
             "ContextConstructable class must have a callable `construct` attribute."
         )

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -20,9 +20,35 @@
 from contextlib import asynccontextmanager
 from typing import Optional
 
+import dependency_injector.resources
+
+
+class ValidResource(dependency_injector.resources.AsyncResource):
+    """
+    An example of an ordinary Resource as defined by the `dependency_injector` framework.
+    """
+
+    class Resource:
+        """Returned upon executing the `init` method."""
+
+        def __init__(self, foo: str = "foo"):
+            """Init TestConstructable."""
+            self.foo: Optional[str] = foo
+            self.in_context = True
+
+    async def init(self, foo: str = "foo") -> Resource:
+        """Initializes a new resource."""
+        return self.Resource(foo=foo)
+
+    async def shutdown(self, resource: Resource) -> None:
+        resource.in_context = False
+
 
 class ValidConstructable:
-    """A test class with a `construct` method that is an async context manager."""
+    """
+    A test class with a `construct` method that is an async context manager.
+    Functionally, this is equivalent to the above `ValidResource` class.
+    """
 
     @classmethod
     @asynccontextmanager

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -25,7 +25,7 @@ import dependency_injector.resources
 
 class ValidResource(dependency_injector.resources.AsyncResource):
     """
-    An example of an ordinary Resource as defined by the `dependency_injector` framework.
+    An example of an AsyncResource as defined by the `dependency_injector` framework.
     """
 
     class Resource:

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -44,6 +44,27 @@ class ValidResource(dependency_injector.resources.AsyncResource):
         resource.in_context = False
 
 
+class ValidSyncResource(dependency_injector.resources.Resource):
+    """
+    An example of an ordinary Resource as defined by the `dependency_injector` framework.
+    """
+
+    class Resource:
+        """Returned upon executing the `init` method."""
+
+        def __init__(self, foo: str = "foo"):
+            """Init TestConstructable."""
+            self.foo: Optional[str] = foo
+            self.in_context = True
+
+    def init(self, foo: str = "foo") -> Resource:  # type: ignore
+        """Initializes a new resource."""
+        return self.Resource(foo=foo)
+
+    def shutdown(self, resource: Resource) -> None:  # type: ignore
+        resource.in_context = False
+
+
 class ValidConstructable:
     """
     A test class with a `construct` method that is an async context manager.

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -1,0 +1,70 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Fixtures and utils for testing the `inject` module."""
+
+
+from contextlib import asynccontextmanager
+from typing import Optional
+
+
+class ValidConstructable:
+    """A test class with a `construct` method that is an async context manager."""
+
+    @classmethod
+    @asynccontextmanager
+    async def construct(cls, foo: str = "foo"):
+        """A constructor with setup and teardown logic."""
+        try:
+            instance = cls(foo=foo)
+            yield instance
+        finally:
+            instance.in_context = False
+
+    def __init__(self, foo: str = "foo"):
+        """Init TestConstructable."""
+        self.foo: Optional[str] = foo
+        self.in_context = True
+
+
+class NoMethodConstructable:
+    """
+    A non valid ContextConstructable:
+    has a `construct` attribute, however, it's not a callable.
+    """
+
+    construct = "invalid"
+
+
+class NoCMConstructable:
+    """
+    A non valid ContextConstructable:
+    has a `construct` method which, however, does not return an async context manager.
+    """
+
+    @classmethod
+    async def construct(cls, foo: str = "foo"):
+        """A constructor with setup and teardown logic."""
+        try:
+            instance = cls(foo=foo)
+            yield instance
+        finally:
+            instance.in_context = False
+
+    def __init__(self, foo: str = "foo"):
+        """Init TestConstructable."""
+        self.foo: Optional[str] = foo
+        self.in_context = True

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -94,3 +94,15 @@ class NoCMConstructable:
         """Init TestConstructable."""
         self.foo: Optional[str] = foo
         self.in_context = True
+
+
+class NonResource:
+    """
+    A class that does not require setup and teardown.
+    Moreover, this class can be used to test the usage of mandatory args and kwargs to
+    the initializer when using dependency injecton constructors.
+    """
+
+    def __init__(self, foo: str, bar: str):
+        self.foo = foo
+        self.bar = bar

--- a/tests/fixtures/inject.py
+++ b/tests/fixtures/inject.py
@@ -36,11 +36,11 @@ class ValidResource(dependency_injector.resources.AsyncResource):
             self.foo: Optional[str] = foo
             self.in_context = True
 
-    async def init(self, foo: str = "foo") -> Resource:
+    async def init(self, foo: str = "foo") -> Resource:  # type: ignore
         """Initializes a new resource."""
         return self.Resource(foo=foo)
 
-    async def shutdown(self, resource: Resource) -> None:
+    async def shutdown(self, resource: Resource) -> None:  # type: ignore
         resource.in_context = False
 
 

--- a/tests/integration/test_inject.py
+++ b/tests/integration/test_inject.py
@@ -1,0 +1,48 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test utilities from the `inject` module."""
+
+import dependency_injector.containers
+import dependency_injector.providers
+import pytest
+
+from hexkit.inject import ContextConstructor
+from tests.fixtures.inject import ValidConstructable
+
+
+@pytest.mark.asyncio
+async def test_context_constructor_with_decl_container():
+    """
+    Test the context constructor together with the `DeclarativeContainer` from the
+    `dependency_injector` framework.
+    """
+
+    foo = "bar"
+
+    class Container(dependency_injector.containers.DeclarativeContainer):
+        test = ContextConstructor(ValidConstructable, foo)
+
+    container = Container()
+    await container.init_resources()
+
+    test_instance = await container.test()
+
+    assert test_instance.foo == foo
+    assert test_instance.in_context
+
+    await container.shutdown_resources()
+    assert not test_instance.in_context

--- a/tests/integration/test_inject.py
+++ b/tests/integration/test_inject.py
@@ -37,14 +37,14 @@ async def test_context_constructor_with_decl_container():
         test = ContextConstructor(ValidConstructable, foo)
 
     container = Container()
-    await container.init_resources()
+    await container.init_resources()  # type: ignore
 
     test_instance = await container.test()
 
     assert test_instance.foo == foo
     assert test_instance.in_context
 
-    await container.shutdown_resources()
+    await container.shutdown_resources()  # type: ignore
     assert not test_instance.in_context
 
 

--- a/tests/integration/test_inject.py
+++ b/tests/integration/test_inject.py
@@ -20,8 +20,8 @@ import dependency_injector.containers
 import dependency_injector.providers
 import pytest
 
-from hexkit.inject import ContextConstructor
-from tests.fixtures.inject import ValidConstructable
+from hexkit.inject import ContainerBase, ContextConstructor
+from tests.fixtures.inject import ValidConstructable, ValidResource
 
 
 @pytest.mark.asyncio
@@ -45,4 +45,32 @@ async def test_context_constructor_with_decl_container():
     assert test_instance.in_context
 
     await container.shutdown_resources()
+    assert not test_instance.in_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provides, constructor",
+    [
+        (ValidResource, dependency_injector.providers.Resource),
+        (ValidConstructable, ContextConstructor),
+    ],
+)
+async def test_container_base(provides, constructor):
+    """
+    Test the ContainerBase and its contextual setup and teardown functionality.
+    """
+
+    foo = "bar"
+
+    class Container(ContainerBase):
+        test = constructor(provides, foo)
+
+    async with Container() as container:
+
+        test_instance = await container.test()
+
+        assert test_instance.foo == foo
+        assert test_instance.in_context
+
     assert not test_instance.in_context

--- a/tests/unit/test_in_mem_pub.py
+++ b/tests/unit/test_in_mem_pub.py
@@ -16,8 +16,9 @@
 
 """Testing the in-memory publisher."""
 
+from contextlib import nullcontext
+
 import pytest
-from black import nullcontext
 
 from hexkit.providers.testing.in_mem_pub import (
     InMemEventPublisher,

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -105,7 +105,8 @@ async def test_context_constructor_setup_teardown(
     test = ContextConstructor(constructable, foo)
 
     with pytest.raises(exception) if exception else nullcontext():  # type: ignore
-        await test()
+        resource = await test.async_()
+        assert isinstance(resource, constructable)
         test_instance = await test.init()  # type: ignore
 
         assert test_instance.foo == foo

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -1,0 +1,85 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test utilities from the `inject` module."""
+
+from contextlib import nullcontext
+from typing import Optional
+
+import dependency_injector.containers
+import dependency_injector.providers
+import pytest
+
+from hexkit.custom_types import ContextConstructable
+from hexkit.inject import ContextConstructor
+from tests.fixtures.inject import (
+    NoCMConstructable,
+    NoMethodConstructable,
+    ValidConstructable,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "constructable, exception",
+    [
+        (ValidConstructable, None),
+        (NoCMConstructable, None),  # passes resources are not initialized in this test
+        (object(), TypeError),
+        (NoMethodConstructable, TypeError),
+    ],
+)
+async def test_context_constructor_init(
+    constructable: ContextConstructable, exception: Optional[Exception]
+):
+    """
+    Test the initialization of a context constructor with valid and invalid
+    constructables.
+    """
+
+    with pytest.raises(exception) if exception else nullcontext():
+        test = ContextConstructor(constructable)
+
+    if not exception:
+        isinstance(test, dependency_injector.providers.Resource)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "constructable, exception",
+    [
+        (ValidConstructable, None),
+        (NoCMConstructable, TypeError),
+    ],
+)
+async def test_context_constructor_setup_teardown(
+    constructable: ContextConstructable, exception: Optional[Exception]
+):
+    """Test whether init and shutdown correctly works with a context constructor."""
+
+    foo = "bar"
+
+    test = ContextConstructor(constructable, foo)
+
+    with pytest.raises(exception) if exception else nullcontext():
+        await test()
+        test_instance = await test.init()
+
+        assert test_instance.foo == foo
+        assert test_instance.in_context
+
+        await test.shutdown()
+        assert not test_instance.in_context

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -67,7 +67,7 @@ async def test_assert_constructable(
     "constructable, exception",
     [
         (ValidConstructable, None),
-        (NoCMConstructable, None),  # passes resources are not initialized in this test
+        (NoCMConstructable, None),  # passed resources are not initialized in this test
         (object(), NotConstructableError),
         (NoMethodConstructable, NotConstructableError),
     ],

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -39,7 +39,7 @@ from tests.fixtures.inject import (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "constructable, raises",
+    "constructable, does_raises",
     [
         (ValidConstructable, False),
         (NoCMConstructable, False),
@@ -50,12 +50,14 @@ from tests.fixtures.inject import (
         (NoMethodConstructable, True),
     ],
 )
-async def test_assert_constructable(constructable: ContextConstructable, raises: bool):
+async def test_assert_constructable(
+    constructable: ContextConstructable, does_raises: bool
+):
     """
     Test that assert_constructable can distinguish between
     """
 
-    with pytest.raises(TypeError) if raises else nullcontext():
+    with pytest.raises(TypeError) if does_raises else nullcontext():  # type: ignore
         assert_context_constructable(constructable)
 
 
@@ -77,7 +79,7 @@ async def test_context_constructor_init(
     constructables.
     """
 
-    with pytest.raises(exception) if exception else nullcontext():
+    with pytest.raises(exception) if exception else nullcontext():  # type: ignore
         test = ContextConstructor(constructable)
 
     if not exception:
@@ -101,14 +103,14 @@ async def test_context_constructor_setup_teardown(
 
     test = ContextConstructor(constructable, foo)
 
-    with pytest.raises(exception) if exception else nullcontext():
+    with pytest.raises(exception) if exception else nullcontext():  # type: ignore
         await test()
-        test_instance = await test.init()
+        test_instance = await test.init()  # type: ignore
 
         assert test_instance.foo == foo
         assert test_instance.in_context
 
-        await test.shutdown()
+        await test.shutdown()  # type: ignore
         assert not test_instance.in_context
 
 

--- a/tests/unit/test_inject.py
+++ b/tests/unit/test_inject.py
@@ -26,6 +26,7 @@ import pytest
 from hexkit.custom_types import ContextConstructable
 from hexkit.inject import (
     ContextConstructor,
+    NotConstructableError,
     assert_context_constructable,
     get_constructor,
 )
@@ -57,7 +58,7 @@ async def test_assert_constructable(
     Test that assert_constructable can distinguish between
     """
 
-    with pytest.raises(TypeError) if does_raises else nullcontext():  # type: ignore
+    with pytest.raises(NotConstructableError) if does_raises else nullcontext():  # type: ignore
         assert_context_constructable(constructable)
 
 
@@ -67,8 +68,8 @@ async def test_assert_constructable(
     [
         (ValidConstructable, None),
         (NoCMConstructable, None),  # passes resources are not initialized in this test
-        (object(), TypeError),
-        (NoMethodConstructable, TypeError),
+        (object(), NotConstructableError),
+        (NoMethodConstructable, NotConstructableError),
     ],
 )
 async def test_context_constructor_init(
@@ -91,7 +92,7 @@ async def test_context_constructor_init(
     "constructable, exception",
     [
         (ValidConstructable, None),
-        (NoCMConstructable, TypeError),
+        (NoCMConstructable, NotConstructableError),
     ],
 )
 async def test_context_constructor_setup_teardown(


### PR DESCRIPTION
```
- Added a class that extends the `dependency_injector`'s Resource provider
   to support classes with a `construct` method that returns an async
   context manager
- Added a class adds an async context manager interface to the
   `DeclarativeContainer` of the `dependency_injector` framework to handle
   the setup and teardown of resources
- Added a helper function that automatically chooses the correct constructor
   for a given class
````