### PR TITLE
protocol to get DAO for basic CRUD (GDEV-993)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,5 +16,5 @@
 [flake8]
 ignore = E, W # ignore all style checks from pycodestyle
               # as they are already checked by black
-exclude = .git,__pycache__,db_migration,build,dist
+exclude = .git,__pycache__,build,dist
 max-complexity = 10

--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# ingore vscode settings:
+# ignore VS Code settings:
 .vscode/
+
+# desktop settings and thumbnails
+.DS_Store
+desktop.ini
+thumbs.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: pylint
         args: [--disable=E0401]
-        exclude: db_migration|tests|.devcontainer
+        exclude: tests|.devcontainer
   - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -19,15 +19,55 @@ with the database."""
 
 import typing
 from abc import ABC, abstractmethod
-from enum import Enum
-from typing import Generic, Literal, Optional, Sequence, TypeVar, Union, overload
+from typing import Literal, Mapping, Optional, Sequence, TypeVar, Union, overload
 
 from pydantic import BaseModel
 
-Dto = TypeVar("Dto", bound=BaseModel, covariant=True, contravariant=False)
-DtoCreation = TypeVar(
-    "DtoCreation", bound=BaseModel, covariant=True, contravariant=False
-)
+# Type variables for handling Data Transfer Objects:
+Dto = TypeVar("Dto", bound=BaseModel)
+DtoCreation = TypeVar("DtoCreation", bound=BaseModel)
+DtoCreation_contra = TypeVar("DtoCreation_contra", bound=BaseModel, contravariant=True)
+
+
+class ResourceNotFoundError(RuntimeError):
+    """Raised when a requested resource did not exist."""
+
+    def __init__(self, *, id_: str):
+        message = f'The resource with the id "{id_}" does not exist.'
+        super().__init__(message)
+
+
+class ResourceAlreadyExistsError(RuntimeError):
+    """Raised when a resource did unexpectedly exist."""
+
+    def __init__(self, *, id_: str):
+        message = f'The resource with the id "{id_}" does already exist.'
+        super().__init__(message)
+
+
+class FindError(RuntimeError):
+    """Base for all error related to DAO find operations."""
+
+
+class NoHitsFoundError(FindError):
+    """Raised when a DAO find operation did not result in any hits but at least one
+    hit was expected."""
+
+    def __init__(self, *, kv: Mapping[str, str]):
+        message = f"No match was found for key-value pairs: {kv}"
+        super().__init__(message)
+
+
+class MultpleHitsFoundError(FindError):
+    """Raised when a DAO find operation did result in multiple hits but while only a
+    single hit was expected."""
+
+    def __init__(self, *, kv: Mapping[str, str]):
+        message = (
+            "Multiple hits were found for the following key-value pairs while only a"
+            f" single one was expected: {kv}"
+        )
+        super().__init__(message)
 
 
 class DaoCommons(typing.Protocol[Dto]):
@@ -43,6 +83,23 @@ class DaoCommons(typing.Protocol[Dto]):
 
         Returns:
             The resource represented using the respective DTO model.
+
+        Raises:
+            ResourceNotFoundError: when resource with the specified id_ was not found
+        """
+        ...
+
+    def update(self, dto: Dto) -> None:
+        """Update an existing resource.
+
+        Args:
+            dto:
+                The updated resource content as a pydantic-based data transfer object
+                including the resource ID.
+
+        Raises:
+            ResourceNotFoundError:
+                when resource with the id specified in the dto was not found
         """
         ...
 
@@ -51,29 +108,37 @@ class DaoCommons(typing.Protocol[Dto]):
 
         Args:
             id_: The ID of the resource.
+
+        Raises:
+            ResourceNotFoundError: when resource with the specified id_ was not found
         """
 
     @overload
-    def find(self, *, kv: dict[str, object], returns: Literal["all"]) -> Sequence[Dto]:
+    def find(
+        self, *, kv: Mapping[str, object], returns: Literal["all"]
+    ) -> Sequence[Dto]:
         ...
 
     @overload
     def find(
-        self, *, kv: dict[str, object], returns: Literal["newest", "oldest", "single"]
+        self,
+        *,
+        kv: Mapping[str, object],
+        returns: Literal["newest", "oldest", "single"],
     ) -> Dto:
         ...
 
     def find(
         self,
         *,
-        kv: dict[str, object],
+        kv: Mapping[str, object],
         returns: Literal["all", "newest", "oldest", "single"] = "all",
     ) -> Union[Sequence[Dto], Dto]:
         """Find resource by specifing a list of key-value pairs that must match.
 
         Args:
             kv:
-                A dictionary where the keys correspond to the name of resource fields
+                A mapping where the keys correspond to the names of resource fields
                 and the values corresponds to the actual values of the resource fields.
             returns:
                 Controls the return behavior. Can be one of: "all" - returns all hits;
@@ -86,11 +151,19 @@ class DaoCommons(typing.Protocol[Dto]):
             If `returns` was set to "all", a sequence of hits is returned. Otherwise will
             return only a single hit. All hits are in the form of the respective DTO
             model.
+
+        Raises:
+            NoHitsFoundError:
+                Raised when no hits where found when used in "newest", "oldest", or
+                "single" mode. When using the "all" mode, zero hits will not cause an
+                exception but simply result in an empty list beeing returned.
+            MultpleHitsFoundError:
+                Raised when obtaining more than one hit when using the "single" mode.
         """
         ...
 
 
-class DaoSurrogateId(DaoCommons[Dto], typing.Protocol[Dto, DtoCreation]):
+class DaoSurrogateId(DaoCommons[Dto], typing.Protocol[Dto, DtoCreation_contra]):
     """A duck type of a DAO that uses that generates an internal/surrogate key for
     indentifying resources in the database. ID/keys cannot be defined by the client of
     the DAO. Thus, both a standard DTO model (first type variable), which includes the
@@ -99,9 +172,46 @@ class DaoSurrogateId(DaoCommons[Dto], typing.Protocol[Dto, DtoCreation]):
     is needed.
     """
 
+    def insert(self, dto: DtoCreation_contra) -> Dto:
+        """Create a new resource.
+
+        Args:
+            dto:
+                Resource content as a pydantic-based data transfer object without the
+                resource ID (which will be set automatically).
+
+        Returns:
+            Returns a copy of the newly inserted resource including it assigned ID.
+        """
+        ...
+
 
 class DaoNaturalId(DaoCommons[Dto], typing.Protocol[Dto]):
     """A duck type of a DAO that uses natural resource ID profided by the client."""
+
+    def insert(self, dto: Dto) -> None:
+        """Create a new resource.
+
+        Args:
+            dto:
+                Resource content as a pydantic-based data transfer object including the
+                resource ID.
+
+        Raises:
+            ResourceAlreadyExistsError:
+                when a resource with the id specified in the dto does already exist.
+        """
+        ...
+
+    def upsert(self, dto: Dto) -> None:
+        """Update the provided resource if it already exists, create it otherwise.
+
+        Args:
+            dto:
+                Resource content as a pydantic-based data transfer object including the
+                resource ID.
+        """
+        ...
 
 
 class DaoFactoryProtcol(ABC):
@@ -109,9 +219,21 @@ class DaoFactoryProtcol(ABC):
     providing a Data Transfer Objetct (DTO) class.
     """
 
+    class DtoIdFieldNotFoundError(ValueError):
+        """Raised when the dto_model did not contain the expected id_field."""
+
+    class DtoCreationModelInvalidInvalid(ValueError):
+        """Raised when the DtoCreationModel was invalid in relation to the main
+        DTO model."""
+
     @overload
     def get_dao(
-        self, *, name: str, dto_model: Dto, id_field: str, fields_to_index: list[str]
+        self,
+        *,
+        name: str,
+        dto_model: type[Dto],
+        id_field: str,
+        fields_to_index: Optional[list[str]],
     ) -> DaoNaturalId[Dto]:
         ...
 
@@ -120,21 +242,22 @@ class DaoFactoryProtcol(ABC):
         self,
         *,
         name: str,
-        dto_model: Dto,
+        dto_model: type[Dto],
         id_field: str,
-        fields_to_index: list[str],
-        dto_creation_model: DtoCreation,
+        fields_to_index: Optional[list[str]],
+        dto_creation_model: type[DtoCreation],
     ) -> DaoSurrogateId[Dto, DtoCreation]:
         ...
 
+    @abstractmethod
     def get_dao(
         self,
         *,
         name: str,
-        dto_model: Dto,
+        dto_model: type[Dto],
         id_field: str,
-        fields_to_index: list[str] = [],
-        dto_creation_model: Optional[DtoCreation] = None,
+        fields_to_index: Optional[list[str]] = None,
+        dto_creation_model: Optional[type[DtoCreation]] = None,
     ) -> Union[DaoSurrogateId[Dto, DtoCreation], DaoNaturalId[Dto]]:
         """Constructs a DAO for interacting with resources in a database.
 
@@ -143,13 +266,13 @@ class DaoFactoryProtcol(ABC):
                 The name of the resource type (roughly equivalent to the name of a
                 database table or collection).
             dto_model:
-                A pydantic model describing the shape of resources.
+                A DTO (Data Transfer Object) model describing the shape of resources.
             id_field:
                 The name of the field of the `dto_model` that serves as resource ID.
                 (DAO implementation might use this field as primary key.)
             fields_to_index:
                 Optionally, provide any fields that should be indexed in addition to the
-                `id_field`. Defaults to `[]`.
+                `id_field`. Defaults to None.
             dto_creation_model:
                 An optional DTO model specific for creation of a new resource. This
                 model has to be identical to the `dto_model` except that it has to miss
@@ -161,5 +284,12 @@ class DaoFactoryProtcol(ABC):
             DaoSurrogateID, which autogenerates IDs upon resource creation, is returned.
             Otherwise, returns a DAO of type DaoNaturalId, which require ID
             specification upon resource creation.
+
+        Raises:
+            self.DtoCreationModelInvalidInvalid:
+                Raised when the DtoCreationModel was invalid in relation to the main
+                DTO model.
+            self.DtoIdFieldNotFoundError:
+                Raised when the dto_model did not contain the expected id_field.
         """
         ...

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -17,10 +17,150 @@
 """Protocol for creating Data Access Objects to perform CRUD (plus find) interactions
 with the database."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
+import typing
+from typing import Literal, Optional, Generic, Sequence, TypeVar, Union, overload
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+Dto = TypeVar("Dto", bound=BaseModel, covariant=True, contravariant=False)
+DtoCreation = TypeVar(
+    "DtoCreation", bound=BaseModel, covariant=True, contravariant=False
+)
+
+
+class DaoCommons(typing.Protocol[Dto]):
+    """A duck type with methods common to all DAOs. This shall be used as base class for
+    other DAO duck types.
+    """
+
+    def get(self, *, id_: str) -> Dto:
+        """Get a resource by providing it's ID.
+
+        Args:
+            id_: The ID of the resource.
+
+        Returns:
+            The resource represented using the respective DTO model.
+        """
+        ...
+
+    def delete(self, *, id_: str) -> None:
+        """Delete a resource by providing it's ID.
+
+        Args:
+            id_: The ID of the resource.
+        """
+
+    @overload
+    def find(self, *, kv: dict[str, object], returns: Literal["all"]) -> Sequence[Dto]:
+        ...
+
+    @overload
+    def find(
+        self, *, kv: dict[str, object], returns: Literal["newest", "oldest", "single"]
+    ) -> Dto:
+        ...
+
+    def find(
+        self,
+        *,
+        kv: dict[str, object],
+        returns: Literal["all", "newest", "oldest", "single"] = "all",
+    ) -> Union[Sequence[Dto], Dto]:
+        """Find resource by specifing a list of key-value pairs that must match.
+
+        Args:
+            kv:
+                A dictionary where the keys correspond to the name of resource fields
+                and the values corresponds to the actual values of the resource fields.
+            returns:
+                Controls the return behavior. Can be one of: "all" - returns all hits;
+                "newest" - returns only the resource of the hit list that was inserted
+                first); "oldest" - returns only the resource of the hist list that was
+                inserted last; "single" - asserts that there will only be one hit
+                (will raise an exception otherwise). Defaults to "all".
+
+        Returns:
+            If `returns` was set to "all", a sequence of hits is returned. Otherwise will
+            return only a single hit. All hits are in the form of the respective DTO
+            model.
+        """
+        ...
+
+
+class DaoSurrogateId(DaoCommons[Dto], typing.Protocol[Dto, DtoCreation]):
+    """A duck type of a DAO that uses that generates an internal/surrogate key for
+    indentifying resources in the database. ID/keys cannot be defined by the client of
+    the DAO. Thus, both a standard DTO model (first type variable), which includes the
+    key field, as well as special DTO model (second type variable), which is identical
+    to the does not include the ID field and is dedicated for creation of new resources,
+    is needed.
+    """
+
+
+class DaoNaturalId(DaoCommons[Dto], typing.Protocol[Dto]):
+    """A duck type of a DAO that uses natural resource ID profided by the client."""
 
 
 class DaoFactoryProtcol(ABC):
     """A Protocol describing a factory to produce Data Access Objects (DAO) objects when
     providing a Data Transfer Objetct (DTO) class.
     """
+
+    @overload
+    def get_dao(
+        self, *, name: str, dto_model: Dto, id_field: str, fields_to_index: list[str]
+    ) -> DaoNaturalId[Dto]:
+        ...
+
+    @overload
+    def get_dao(
+        self,
+        *,
+        name: str,
+        dto_model: Dto,
+        id_field: str,
+        fields_to_index: list[str],
+        dto_creation_model: DtoCreation,
+    ) -> DaoSurrogateId[Dto, DtoCreation]:
+        ...
+
+    def get_dao(
+        self,
+        *,
+        name: str,
+        dto_model: Dto,
+        id_field: str,
+        fields_to_index: list[str] = [],
+        dto_creation_model: Optional[DtoCreation] = None,
+    ) -> Union[DaoSurrogateId[Dto, DtoCreation], DaoNaturalId[Dto]]:
+        """Constructs a DAO for interacting with resources in a database.
+
+        Args:
+            name:
+                The name of the resource type (roughly equivalent to the name of a
+                database table or collection).
+            dto_model:
+                A pydantic model describing the shape of resources.
+            id_field:
+                The name of the field of the `dto_model` that serves as resource ID.
+                (DAO implementation might use this field as primary key.)
+            fields_to_index:
+                Optionally, provide any fields that should be indexed in addition to the
+                `id_field`. Defaults to `[]`.
+            dto_creation_model:
+                An optional DTO model specific for creation of a new resource. This
+                model has to be identical to the `dto_model` except that it has to miss
+                the `id_field`. If specified, resource ID will be generated by the DAO
+                implementation upon. Otherwise (if set to None), resource IDs have to
+                be specified upon resource creation. Defaults to None.
+        Returns:
+            If a dedicated `dto_creation_model` is specified, a DAO of type
+            DaoSurrogateID, which autogenerates IDs upon resource creation, is returned.
+            Otherwise, returns a DAO of type DaoNaturalId, which require ID
+            specification upon resource creation.
+        """
+        ...

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -1,0 +1,26 @@
+# Copyright 2021 - 2022 Universität Tübingen, DKFZ and EMBL
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Protocol for creating Data Access Objects to perform CRUD (plus find) interactions
+with the database."""
+
+from abc import ABC
+
+
+class DaoFactoryProtcol(ABC):
+    """A Protocol describing a factory to produce Data Access Objects (DAO) objects when
+    providing a Data Transfer Objetct (DTO) class.
+    """

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -17,13 +17,12 @@
 """Protocol for creating Data Access Objects to perform CRUD (plus find) interactions
 with the database."""
 
-from abc import ABC, abstractmethod
 import typing
-from typing import Literal, Optional, Generic, Sequence, TypeVar, Union, overload
+from abc import ABC, abstractmethod
 from enum import Enum
+from typing import Generic, Literal, Optional, Sequence, TypeVar, Union, overload
 
 from pydantic import BaseModel
-
 
 Dto = TypeVar("Dto", bound=BaseModel, covariant=True, contravariant=False)
 DtoCreation = TypeVar(

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -62,7 +62,6 @@ EXCLUDE = [
     ".vscode",
     ".mypy_cache",
     ".mypy.ini",
-    "db_migration",
     ".pytest_cache",
     ".editorconfig",
     ".static_files",


### PR DESCRIPTION
```
Provides a factory for creating DAOs with basic CRUD + find actions.
Thereby, it distinguishes between the use case
that a natural resource ID is available and
the alternative case that the resource ID is
generated by the DAO upon resource creation.
```

Implementation that will be part of the Protocol directly will be provided in a separate PR.