### PR TITLE
standardize configuration of providers (GDEV-1206)

### DIFF
--- a/examples/stream_calc/sc_tests/unit/test_eventpub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventpub.py
@@ -17,7 +17,10 @@
 """Testing the `translators.eventpub` module."""
 
 import pytest
-from stream_calc.translators.eventpub import EventResultEmitter
+from stream_calc.translators.eventpub import (
+    EventResultEmitter,
+    EventResultEmitterConfig,
+)
 
 from hexkit.providers.testing.eventpub import InMemEventPublisher
 
@@ -33,10 +36,13 @@ async def test_emit_result():
     failure_type = "test_fail"
     event_publisher = InMemEventPublisher()
 
+    config = EventResultEmitterConfig(
+        result_emit_output_topic=output_topic,
+        result_emit_success_type=success_type,
+        result_emit_failure_type=failure_type,
+    )
     result_emitter = EventResultEmitter(
-        output_topic=output_topic,
-        success_type=success_type,
-        failure_type=failure_type,
+        config=config,
         event_publisher=event_publisher,
     )
     await result_emitter.emit_result(problem_id=problem_id, result=result)
@@ -59,10 +65,13 @@ async def test_emit_failure():
     failure_type = "test_fail"
     event_publisher = InMemEventPublisher()
 
+    config = EventResultEmitterConfig(
+        result_emit_output_topic=output_topic,
+        result_emit_success_type=success_type,
+        result_emit_failure_type=failure_type,
+    )
     result_emitter = EventResultEmitter(
-        output_topic=output_topic,
-        success_type=success_type,
-        failure_type=failure_type,
+        config=config,
         event_publisher=event_publisher,
     )
     await result_emitter.emit_failure(problem_id=problem_id, reason=reason)

--- a/examples/stream_calc/sc_tests/unit/test_eventsub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventsub.py
@@ -19,7 +19,10 @@
 from unittest.mock import AsyncMock
 
 import pytest
-from stream_calc.translators.eventsub import EventProblemReceiver
+from stream_calc.translators.eventsub import (
+    EventProblemReceiver,
+    EventProblemReceiverConfig,
+)
 
 from hexkit.custom_types import JsonObject
 
@@ -49,7 +52,7 @@ async def test_event_problem_receiver(
     problem_handler = AsyncMock()
 
     problem_receiver = EventProblemReceiver(
-        topics_of_interest=[topic], problem_handler=problem_handler
+        config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
     await problem_receiver.consume(payload=payload, type_=type_, topic=topic)
 
@@ -66,7 +69,7 @@ async def test_event_problem_receiver_with_missing_field():
     payload: JsonObject = {"problem_id": "bad_problem", "multiplier": 0}
     problem_handler = AsyncMock()
     problem_receiver = EventProblemReceiver(
-        topics_of_interest=[topic], problem_handler=problem_handler
+        config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
     with pytest.raises(
         EventProblemReceiver.MalformedPayloadError,

--- a/examples/stream_calc/stream_calc/config.py
+++ b/examples/stream_calc/stream_calc/config.py
@@ -18,17 +18,20 @@
 
 from typing import Literal
 
-from pydantic import BaseSettings
+from hexkit.providers.akafka import KafkaConfig
 
 LOGLEVEL = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
-class Config(BaseSettings):
+class Config(KafkaConfig):
     """Config parameters and their defaults."""
 
+    # adding defaults to params defined in the KafkaConfig, just for convenience in this
+    # example:
     service_name: str = "stream_calc"
-    client_suffix: str = "1"
+    service_instance_id: str = "1"
     kafka_servers: list[str] = ["kafka:9092"]
+
     log_level: LOGLEVEL = "INFO"
     result_emit_output_topic: str = "calc_output"
     result_emit_success_type: str = "calc_success"

--- a/examples/stream_calc/stream_calc/config.py
+++ b/examples/stream_calc/stream_calc/config.py
@@ -18,12 +18,15 @@
 
 from typing import Literal
 
+from stream_calc.translators.eventpub import EventResultEmitterConfig
+from stream_calc.translators.eventsub import EventProblemReceiverConfig
+
 from hexkit.providers.akafka import KafkaConfig
 
 LOGLEVEL = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
-class Config(KafkaConfig):
+class Config(KafkaConfig, EventProblemReceiverConfig, EventResultEmitterConfig):
     """Config parameters and their defaults."""
 
     # adding defaults to params defined in the KafkaConfig, just for convenience in this
@@ -33,7 +36,3 @@ class Config(KafkaConfig):
     kafka_servers: list[str] = ["kafka:9092"]
 
     log_level: LOGLEVEL = "INFO"
-    result_emit_output_topic: str = "calc_output"
-    result_emit_success_type: str = "calc_success"
-    result_emit_failure_type: str = "calc_failure"
-    problem_receive_topics: list[str] = ["arithmetic_problems"]

--- a/examples/stream_calc/stream_calc/container.py
+++ b/examples/stream_calc/stream_calc/container.py
@@ -24,6 +24,7 @@
 from dependency_injector import providers
 
 # pylint: disable=wrong-import-order
+from stream_calc.config import Config
 from stream_calc.core.calc import StreamCalculator
 from stream_calc.translators.eventpub import EventResultEmitter
 from stream_calc.translators.eventsub import EventProblemReceiver
@@ -40,9 +41,7 @@ class Container(ContainerBase):
     # outbound providers:
     event_publisher = get_constructor(
         KafkaEventPublisher,
-        service_name=config.service_name,
-        client_suffix=config.client_suffix,
-        kafka_servers=config.kafka_servers,
+        config=config,
     )
 
     # outbound translators:
@@ -69,8 +68,6 @@ class Container(ContainerBase):
     # inbound providers:
     event_subscriber = get_constructor(
         KafkaEventSubscriber,
-        service_name=config.service_name,
-        client_suffix=config.client_suffix,
-        kafka_servers=config.kafka_servers,
+        config=config,
         translator=event_problem_receiver,
     )

--- a/examples/stream_calc/stream_calc/container.py
+++ b/examples/stream_calc/stream_calc/container.py
@@ -21,15 +21,13 @@
 
 """Module hosting the dependency injection container."""
 
-from dependency_injector import providers
-
 # pylint: disable=wrong-import-order
 from stream_calc.config import Config
 from stream_calc.core.calc import StreamCalculator
 from stream_calc.translators.eventpub import EventResultEmitter
 from stream_calc.translators.eventsub import EventProblemReceiver
 
-from hexkit.inject import ContainerBase, get_constructor, get_configurator, Configurator
+from hexkit.inject import ContainerBase, get_configurator, get_constructor
 from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
 
 
@@ -47,9 +45,7 @@ class Container(ContainerBase):
     # outbound translators:
     event_result_emitter = get_constructor(
         EventResultEmitter,
-        output_topic=config.result_emit_output_topic,
-        success_type=config.result_emit_success_type,
-        failure_type=config.result_emit_failure_type,
+        config=config,
         event_publisher=event_publisher,
     )
 
@@ -61,7 +57,7 @@ class Container(ContainerBase):
     # inbound translators:
     event_problem_receiver = get_constructor(
         EventProblemReceiver,
-        topics_of_interest=config.problem_receive_topics,
+        config=config,
         problem_handler=problem_handler,
     )
 

--- a/examples/stream_calc/stream_calc/container.py
+++ b/examples/stream_calc/stream_calc/container.py
@@ -29,14 +29,14 @@ from stream_calc.core.calc import StreamCalculator
 from stream_calc.translators.eventpub import EventResultEmitter
 from stream_calc.translators.eventsub import EventProblemReceiver
 
-from hexkit.inject import ContainerBase, get_constructor
+from hexkit.inject import ContainerBase, get_constructor, get_configurator, Configurator
 from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
 
 
 class Container(ContainerBase):
     """DI Container"""
 
-    config = providers.Configuration()
+    config = get_configurator(Config)
 
     # outbound providers:
     event_publisher = get_constructor(

--- a/examples/stream_calc/stream_calc/main.py
+++ b/examples/stream_calc/stream_calc/main.py
@@ -33,7 +33,7 @@ def get_container(config: Config) -> Container:
     logging.basicConfig(level=config.log_level)
 
     container = Container()
-    container.config.from_pydantic(config)
+    container.config.load_from(config)
 
     return container
 

--- a/examples/stream_calc/stream_calc/main.py
+++ b/examples/stream_calc/stream_calc/main.py
@@ -33,7 +33,7 @@ def get_container(config: Config) -> Container:
     logging.basicConfig(level=config.log_level)
 
     container = Container()
-    container.config.load_from(config)
+    container.config.load_config(config)
 
     return container
 

--- a/examples/stream_calc/stream_calc/translators/eventpub.py
+++ b/examples/stream_calc/stream_calc/translators/eventpub.py
@@ -16,10 +16,19 @@
 
 """Translators that target the event publishing protocol."""
 
+from pydantic import BaseSettings
 from stream_calc.ports.result_emitter import CalcResultEmitterPort
 
 from hexkit.custom_types import JsonObject
 from hexkit.protocols.eventpub import EventPublisherProtocol
+
+
+class EventResultEmitterConfig(BaseSettings):
+    """Config parameters and their defaults."""
+
+    result_emit_output_topic: str = "calc_output"
+    result_emit_success_type: str = "calc_success"
+    result_emit_failure_type: str = "calc_failure"
 
 
 class EventResultEmitter(CalcResultEmitterPort):
@@ -29,17 +38,15 @@ class EventResultEmitter(CalcResultEmitterPort):
     def __init__(
         self,
         *,
-        output_topic: str,
-        success_type: str,
-        failure_type: str,
+        config: EventResultEmitterConfig,
         event_publisher: EventPublisherProtocol
     ) -> None:
         """Configure with provider for the the EventPublisherProto"""
 
         self._event_publisher = event_publisher
-        self._output_topic = output_topic
-        self._success_type = success_type
-        self._failure_type = failure_type
+        self._output_topic = config.result_emit_output_topic
+        self._success_type = config.result_emit_success_type
+        self._failure_type = config.result_emit_failure_type
 
     async def emit_result(self, *, problem_id: str, result: float) -> None:
         """Emits the result of the calc task with the given ID."""

--- a/examples/stream_calc/stream_calc/translators/eventsub.py
+++ b/examples/stream_calc/stream_calc/translators/eventsub.py
@@ -16,10 +16,17 @@
 
 """Translators that target the event publishing protocol."""
 
+from pydantic import BaseSettings
 from stream_calc.ports.problem_receiver import ArithProblemHandlerPort
 
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.protocols.eventsub import EventSubscriberProtocol
+
+
+class EventProblemReceiverConfig(BaseSettings):
+    """Config parameters and their defaults."""
+
+    problem_receive_topics: list[str] = ["arithmetic_problems"]
 
 
 class EventProblemReceiver(EventSubscriberProtocol):
@@ -31,12 +38,12 @@ class EventProblemReceiver(EventSubscriberProtocol):
     def __init__(
         self,
         *,
-        topics_of_interest: list[str],
+        config: EventProblemReceiverConfig,
         problem_handler: ArithProblemHandlerPort,
     ):
         """Configure the translator with a corresponding port implementation."""
         self._problem_handler = problem_handler
-        self.topics_of_interest = topics_of_interest
+        self.topics_of_interest = config.problem_receive_topics
 
     @classmethod
     def _extract_payload(cls, payload: JsonObject, expected_fields: list[str]) -> tuple:

--- a/hexkit/config.py
+++ b/hexkit/config.py
@@ -168,6 +168,8 @@ def config_from_yaml(
                 class Config:
                     """pydantic Config subclass"""
 
+                    frozen = True
+
                     # add this prefix to all variable names to
                     # define them as environment variables:
                     env_prefix = f"{prefix}_"

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -199,15 +199,30 @@ class Configurator(dependency_injector.providers.Factory, Generic[PydanticConfig
 
     Please note: While this is specific for reflecting"""
 
-    def load_from(self, config: PydanticConfig):
+    def load_config(self, config: PydanticConfig):
         """"""
 
         self.override(dependency_injector.providers.Callable(lambda: config))
 
+    def resolve(self):
+        """"""
+
+        if len(self.overridden) > 0:
+            if isinstance(self.last_overriding, dependency_injector.providers.Callable):
+                return self.last_overriding.provides()
+
+            raise RuntimeError(
+                "A Configurator should only be overwritten with a provider of type"
+                + " 'dependency_injector.providers.Callable' but got: "
+                + str(type(self.last_overriding))
+            )
+
+        return self.provides()
+
     def get(self, param_name: str):
 
         return dependency_injector.providers.Callable(
-            lambda: getattr(self.provides(), param_name)
+            lambda: getattr(self.resolve(), param_name)
         )
 
     def __getattr__(self, attr):

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -195,48 +195,20 @@ PydanticConfig = TypeVar("PydanticConfig", bound=BaseSettings)
 
 class Configurator(dependency_injector.providers.Factory, Generic[PydanticConfig]):
     """A configuration constructor that holds configuration parameters using a pydantic
-    model.
-
-    Please note: While this is specific for reflecting"""
+    model."""
 
     def load_config(self, config: PydanticConfig):
-        """"""
+        """Loading config parameters form an pydantic config instance."""
 
         self.override(dependency_injector.providers.Callable(lambda: config))
-
-    def resolve(self):
-        """"""
-
-        if len(self.overridden) > 0:
-            if isinstance(self.last_overriding, dependency_injector.providers.Callable):
-                return self.last_overriding.provides()
-
-            raise RuntimeError(
-                "A Configurator should only be overwritten with a provider of type"
-                + " 'dependency_injector.providers.Callable' but got: "
-                + str(type(self.last_overriding))
-            )
-
-        return self.provides()
-
-    def get(self, param_name: str):
-
-        return dependency_injector.providers.Callable(
-            lambda: getattr(self.resolve(), param_name)
-        )
-
-    def __getattr__(self, attr):
-
-        if attr.startswith("__") and attr.endswith("__"):
-            return super().__getattr__(attr)
-
-        return self.get(attr)
 
 
 def get_configurator(
     pydantic_cls: type[PydanticConfig],
 ) -> Configurator[PydanticConfig]:
-    """Automatically selects and applies the right constructor for the class given to
-    `provides`."""
+    """Initializes a configuration provider.
+
+    This helper function is necessary because the __init__ of Providers used by the
+    dependency_injector framework need to always use the same singnature."""
 
     return Configurator[PydanticConfig](pydantic_cls)

--- a/hexkit/providers/akafka.py
+++ b/hexkit/providers/akafka.py
@@ -34,7 +34,6 @@ from hexkit.custom_types import JsonObject
 from hexkit.protocols.eventpub import EventPublisherProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 
-
 __all__ = [
     "KafkaConfig",
     "KafkaEventPublisher",

--- a/hexkit/providers/akafka.py
+++ b/hexkit/providers/akafka.py
@@ -27,6 +27,7 @@ from contextlib import asynccontextmanager
 from typing import Any, Callable, Literal, Protocol
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from pydantic import BaseSettings, Field
 
 from hexkit.base import InboundProviderBase
 from hexkit.custom_types import JsonObject
@@ -34,16 +35,48 @@ from hexkit.protocols.eventpub import EventPublisherProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 
 
+__all__ = [
+    "KafkaConfig",
+    "KafkaEventPublisher",
+    "ConsumerEvent",
+    "KafkaEventSubscriber",
+]
+
+
+class KafkaConfig(BaseSettings):
+    """Config parameters needed for connecting to Apache Kafka."""
+
+    service_name: str = Field(
+        ...,
+        example="my-cool-special-service",
+        description="The name of the (micro-)service from which messages are published.",
+    )
+    service_instance_id: str = Field(
+        ...,
+        example="germany-bw-instance-001",
+        description=(
+            "A string that uniquely identifies this instance across all instances of"
+            + " this service. A globally unique Kafka client ID will be created by"
+            + " concatenating the service_name and the service_instance_id."
+        ),
+    )
+    kafka_servers: list[str] = Field(
+        ...,
+        example=["localhost:9092"],
+        description="A list of connection strings to connect to Kafka bootstrap servers.",
+    )
+
+
 class EventTypeNotFoundError(RuntimeError):
     """Thrown when no `type` was set in the headers of an event."""
 
 
-def generate_client_id(service_name: str, client_suffix: str) -> str:
+def generate_client_id(*, service_name: str, instance_id: str) -> str:
     """
     Generate client id (from the perspective of the Kafka broker) by concatenating
     the service name and the client suffix.
     """
-    return f"{service_name}.{client_suffix}"
+    return f"{service_name}.{instance_id}"
 
 
 class KafkaProducerCompatible(Protocol):
@@ -92,29 +125,24 @@ class KafkaEventPublisher(EventPublisherProtocol):
     async def construct(
         cls,
         *,
-        service_name: str,
-        client_suffix: str,
-        kafka_servers: list[str],
+        config: KafkaConfig,
         kafka_producer_cls: type[KafkaProducerCompatible] = AIOKafkaProducer,
     ):
         """
         Setup and teardown KafkaEventPublisher instance with some config params.
 
         Args:
-            service_name (str):
-                The name of the (micro-)service from which messages are published.
-            client_suffix (str):
-                String that uniquely identifies this instance across all instances of this
-                service. Will create a globally unique Kafka client ID by concatenating
-            kafka_servers (list[str]):
-                List of connection strings pointing to the kafka brokers.
+            config:
+                Config parameters needed for connecting to Apache Kafka.
             kafka_producer_cls:
                 Overwrite the used Kafka Producer class. Only intented for unit testing.
         """
-        client_id = generate_client_id(service_name, client_suffix)
+        client_id = generate_client_id(
+            service_name=config.service_name, instance_id=config.service_instance_id
+        )
 
         producer = kafka_producer_cls(
-            bootstrap_servers=kafka_servers,
+            bootstrap_servers=config.kafka_servers,
             client_id=client_id,
             key_serializer=lambda key: key.encode("ascii"),
             value_serializer=lambda event_value: json.dumps(event_value).encode(
@@ -227,9 +255,7 @@ class KafkaEventSubscriber(InboundProviderBase):
     async def construct(
         cls,
         *,
-        service_name: str,
-        client_suffix: str,
-        kafka_servers: list[str],
+        config: KafkaConfig,
         translator: EventSubscriberProtocol,
         kafka_consumer_cls: type[KafkaConsumerCompatible] = AIOKafkaConsumer,
     ):
@@ -237,14 +263,8 @@ class KafkaEventSubscriber(InboundProviderBase):
         Setup and teardown KafkaEventPublisher instance with some config params.
 
         Args:
-            service_name (str):
-                The name of the (micro-)service from which messages are published.
-            client_suffix (str):
-                String that uniquely this instance across all instances of this service.
-                Will create a globally unique Kafka client IDidentifier by concatenating
-                the service_name and the client_suffix.
-            kafka_servers (list[str]):
-                List of connection strings pointing to the kafka brokers.
+            config:
+                Config parameters needed for connecting to Apache Kafka.
             translator (EventSubscriberProtocol):
                 The translator that translates between the protocol (mentioned in the
                 type annotation) and an application-specific port
@@ -253,15 +273,17 @@ class KafkaEventSubscriber(InboundProviderBase):
                 Overwrite the used Kafka consumer class. Only intented for unit testing.
         """
 
-        client_id = generate_client_id(service_name, client_suffix)
+        client_id = generate_client_id(
+            service_name=config.service_name, instance_id=config.service_instance_id
+        )
 
         topics = translator.topics_of_interest
 
         consumer = kafka_consumer_cls(
             *topics,
-            bootstrap_servers=kafka_servers,
+            bootstrap_servers=config.kafka_servers,
             client_id=client_id,
-            group_id=service_name,
+            group_id=config.service_name,
             auto_offset_reset="earliest",
             key_deserializer=lambda event_key: event_key.decode("ascii"),
             value_deserializer=lambda event_value: json.loads(

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -24,7 +24,11 @@ from kafka import KafkaConsumer, KafkaProducer
 from testcontainers.kafka import KafkaContainer
 
 from hexkit.custom_types import JsonObject
-from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
+from hexkit.providers.akafka import (
+    KafkaEventPublisher,
+    KafkaEventSubscriber,
+    KafkaConfig,
+)
 from tests.fixtures.utils import exec_with_timeout
 
 
@@ -38,12 +42,13 @@ async def test_kafka_event_publisher():
 
     with KafkaContainer() as kafka:
         bootstrap_servers = [kafka.get_bootstrap_server()]
-
-        async with KafkaEventPublisher.construct(
+        config = KafkaConfig(
             service_name="test_publisher",
-            client_suffix="1",
+            service_instance_id="1",
             kafka_servers=bootstrap_servers,
-        ) as event_publisher:
+        )
+
+        async with KafkaEventPublisher.construct(config=config) as event_publisher:
 
             await event_publisher.publish(
                 payload=payload,
@@ -93,9 +98,11 @@ async def test_kafka_event_subscriber():
 
     with KafkaContainer() as kafka:
         # publish one event the python-kafka library directly:
+        bootstrap_servers = [kafka.get_bootstrap_server()]
+
         producer = KafkaProducer(
             client_id="test_producer",
-            bootstrap_servers=[kafka.get_bootstrap_server()],
+            bootstrap_servers=bootstrap_servers,
             key_serializer=lambda key: key.encode("ascii"),
             value_serializer=lambda event_value: json.dumps(event_value).encode(
                 "ascii"
@@ -107,10 +114,13 @@ async def test_kafka_event_subscriber():
             producer.close()
 
         # setup the provider:
-        async with KafkaEventSubscriber.construct(
+        config = KafkaConfig(
             service_name="event_subscriber",
-            client_suffix="1",
-            kafka_servers=[kafka.get_bootstrap_server()],
+            service_instance_id="1",
+            kafka_servers=bootstrap_servers,
+        )
+        async with KafkaEventSubscriber.construct(
+            config=config,
             translator=translator,
         ) as event_subscriber:
             # consume one event:

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -25,9 +25,9 @@ from testcontainers.kafka import KafkaContainer
 
 from hexkit.custom_types import JsonObject
 from hexkit.providers.akafka import (
+    KafkaConfig,
     KafkaEventPublisher,
     KafkaEventSubscriber,
-    KafkaConfig,
 )
 from tests.fixtures.utils import exec_with_timeout
 

--- a/tests/integration/test_inject.py
+++ b/tests/integration/test_inject.py
@@ -16,11 +16,20 @@
 
 """Test utilities from the `inject` module."""
 
+from contextlib import asynccontextmanager
+
 import dependency_injector.containers
 import dependency_injector.providers
 import pytest
+from pydantic import BaseSettings
 
-from hexkit.inject import AsyncInitShutdownError, ContainerBase, ContextConstructor
+from hexkit.inject import (
+    AsyncInitShutdownError,
+    ContainerBase,
+    ContextConstructor,
+    get_configurator,
+    get_constructor,
+)
 from tests.fixtures.inject import ValidConstructable, ValidResource, ValidSyncResource
 
 
@@ -96,3 +105,80 @@ async def test_container_base_sync_resouce():
 
     with pytest.raises(AsyncInitShutdownError):
         await container.__aexit__(..., ..., ...)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("load_config", [True, False])
+async def test_configurator(load_config: bool):
+    """Test the configurator with default config parameters."""
+
+    class ExampleConfig(BaseSettings):
+        """A collection of example config parameter and their defaults."""
+
+        param_a: str = "foo"
+        param_b: int = 27
+        param_c: bool = True
+
+    # If load_config is false, the default config values are expected, otherwise a
+    # custom set of values is used:
+    expected_config = (
+        ExampleConfig(param_a="bar", param_b=28) if load_config else ExampleConfig()
+    )
+
+    class FullConfigConsumer:
+        """A class that consumes an entire ExampleConfig instance (and not just
+        individual parameters)."""
+
+        @classmethod
+        @asynccontextmanager
+        async def construct(cls, *, config: ExampleConfig):
+            """A constructor with setup and teardown logic.
+            Just there so that we can use the container as an async context manager."""
+
+            yield cls(config=config)
+
+        def __init__(self, *, config: ExampleConfig):
+            """Takes an ExampleConfig instance and checks their values against the
+            expectation."""
+
+            self.config = config
+
+    class IndividualConfigParamConsumer:
+        """A class that consumes individual config parameters."""
+
+        @classmethod
+        @asynccontextmanager
+        async def construct(cls, *, param_a: str, param_b: int):
+            """A constructor with setup and teardown logic.
+            Just there so that we can use the container as an async context manager."""
+
+            yield cls(param_a=param_a, param_b=param_b)
+
+        def __init__(self, *, param_a: str, param_b: int):
+            """Takes individual config parameters and checks their values against the
+            expectation."""
+
+            self.param_a = param_a
+            self.param_b = param_b
+
+    class Container(ContainerBase):
+        config = get_configurator(ExampleConfig)
+        full_config_consumer = get_constructor(FullConfigConsumer, config=config)
+        config_param_consumer = get_constructor(
+            IndividualConfigParamConsumer,
+            param_a=config.param_a,
+            param_b=config.param_b,
+        )
+        test = ContextConstructor(ValidConstructable, "foo")
+
+    container_cm = Container()
+
+    container_cm.config.load_config(expected_config)
+    async with container_cm as container:
+
+        # Construct consumers:
+        full_config_consumer = await container.full_config_consumer()
+        config_param_consumer = await container.config_param_consumer()
+
+        # Check the consumed values:
+        assert full_config_consumer.config.dict() == expected_config.dict()

--- a/tests/integration/test_inject.py
+++ b/tests/integration/test_inject.py
@@ -173,7 +173,8 @@ async def test_configurator(load_config: bool):
 
     container_cm = Container()
 
-    container_cm.config.load_config(expected_config)
+    if load_config:
+        container_cm.config.load_config(expected_config)
     async with container_cm as container:
 
         # Construct consumers:
@@ -182,3 +183,5 @@ async def test_configurator(load_config: bool):
 
         # Check the consumed values:
         assert full_config_consumer.config.dict() == expected_config.dict()
+        assert config_param_consumer.param_a == expected_config.param_a
+        assert config_param_consumer.param_b == expected_config.param_b

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -47,7 +47,7 @@ async def test_kafka_event_publisher():
     # publish event using the provider:
     config = KafkaConfig(
         service_name="test_publisher",
-        client_suffix="1",
+        service_instance_id="1",
         kafka_servers=["my-fake-kafka-server"],
     )
     async with KafkaEventPublisher.construct(
@@ -159,7 +159,7 @@ async def test_kafka_event_subscriber(
     # setup the provider:
     config = KafkaConfig(
         service_name=service_name,
-        client_suffix="1",
+        service_instance_id="1",
         kafka_servers=["my-fake-kafka-server"],
     )
     async with KafkaEventSubscriber.construct(

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -24,7 +24,11 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 from hexkit.custom_types import JsonObject
-from hexkit.providers.akafka import KafkaEventPublisher, KafkaEventSubscriber
+from hexkit.providers.akafka import (
+    KafkaConfig,
+    KafkaEventPublisher,
+    KafkaEventSubscriber,
+)
 
 
 @pytest.mark.asyncio
@@ -41,10 +45,13 @@ async def test_kafka_event_publisher():
     producer_class = Mock(return_value=producer)
 
     # publish event using the provider:
-    async with KafkaEventPublisher.construct(
+    config = KafkaConfig(
         service_name="test_publisher",
         client_suffix="1",
         kafka_servers=["my-fake-kafka-server"],
+    )
+    async with KafkaEventPublisher.construct(
+        config=config,
         kafka_producer_cls=producer_class,
     ) as event_publisher:
 
@@ -150,10 +157,13 @@ async def test_kafka_event_subscriber(
     translator.types_of_interest = types_of_interest
 
     # setup the provider:
-    async with KafkaEventSubscriber.construct(
+    config = KafkaConfig(
         service_name=service_name,
         client_suffix="1",
         kafka_servers=["my-fake-kafka-server"],
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config,
         translator=translator,
         kafka_consumer_cls=consumer_cls,
     ) as event_subscriber:


### PR DESCRIPTION
For squash and merge:
```
All providers now take a pydantic model as
config argument. Also added a Configurator that is specific for handling
configuration based on pydantic for dependency injection.
```