### PR TITLE
curate and harmonize dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: isort
         args: [--profile, black]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.981
     hooks:
       - id: mypy
         args: [--no-warn-unused-ignores]

--- a/hexkit/__init__.py
+++ b/hexkit/__init__.py
@@ -15,4 +15,4 @@
 
 """A Toolkit for Building Microservices using the Hexagonal Architecture"""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,9 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    pydantic>=1.8.2
-    PyYAML>=5.4.1
-    dependency-injector>=4.39.1
+    pydantic==1.10.2
+    PyYAML==5.4.1
+    dependency-injector==4.39.1
 python_requires = >= 3.9
 
 [options.package_data]
@@ -49,7 +49,7 @@ python_requires = >= 3.9
 
 [options.extras_require]
 akafka =
-    aiokafka~=0.7.2
+    aiokafka==0.7.2
     jsonschema>=3.2.0
 s3 =
     boto3==1.18.28


### PR DESCRIPTION
Description:
```
For now, pin all dependencies to achieve harmonization across reyling services.
Later the dependencies should be relaxed and pinning at the service side should happen through lock files.

Moreover, harmonized the mypy versions in the setup.cfg and the pre-commit config.

Bump version to 0.3.2.

Co-authored-by: Christoph Zwerschke <cito@online.de>
```