### PR TITLE
raise exceptions when no hits for find_one (GDEV-1406)

### DIFF
--- a/hexkit/__init__.py
+++ b/hexkit/__init__.py
@@ -15,4 +15,4 @@
 
 """A Toolkit for Building Microservices using the Hexagonal Architecture"""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -83,7 +83,7 @@ class MultipleHitsFoundError(FindError):
 
 
 class NoHitsFoundError(FindError):
-    """Raised when a DAO find operation did result in multiple hits while only a
+    """Raised when a DAO find operation did result in no hits while a
     single hit was expected."""
 
     def __init__(self, *, mapping: Mapping[str, str]):

--- a/hexkit/protocols/dao.py
+++ b/hexkit/protocols/dao.py
@@ -82,6 +82,18 @@ class MultipleHitsFoundError(FindError):
         super().__init__(message)
 
 
+class NoHitsFoundError(FindError):
+    """Raised when a DAO find operation did result in multiple hits while only a
+    single hit was expected."""
+
+    def __init__(self, *, mapping: Mapping[str, str]):
+        message = (
+            "No hits were found for the following key-value pairs while a single one"
+            + " was expected: {mapping}"
+        )
+        super().__init__(message)
+
+
 class DaoCommons(typing.Protocol[Dto]):
     """A duck type with methods common to all DAOs. This shall be used as base class for
     other DAO duck types.
@@ -141,6 +153,8 @@ class DaoCommons(typing.Protocol[Dto]):
             was found.
 
         Raises:
+            NoHitsFoundError:
+                If no hit was found.
             MultpleHitsFoundError:
                 Raised when obtaining more than one hit.
         """

--- a/hexkit/providers/mongodb/provider.py
+++ b/hexkit/providers/mongodb/provider.py
@@ -192,7 +192,7 @@ class MongoDbDaoBase(ABC, Generic[Dto]):
         Raises:
             NoHitsFoundError:
                 If no hit was found.
-            MultpleHitsFoundError:
+            MultipleHitsFoundError:
                 Raised when obtaining more than one hit.
         """
 

--- a/hexkit/providers/mongodb/provider.py
+++ b/hexkit/providers/mongodb/provider.py
@@ -41,6 +41,7 @@ from hexkit.protocols.dao import (
     DtoCreation_contra,
     InvalidFindMappingError,
     MultipleHitsFoundError,
+    NoHitsFoundError,
     ResourceNotFoundError,
 )
 from hexkit.utils import FieldNotInModelError, validate_fields_in_model
@@ -183,27 +184,24 @@ class MongoDbDaoBase(ABC, Generic[Dto]):
             mapping:
                 A mapping where the keys correspond to the names of resource fields
                 and the values correspond to the actual values of the resource fields
-            mode:
-                One of: "single" (asserts that there will be at most one hit, will raise
-                an exception otherwise), "newest" (returns only the resource of the hit
-                list that was inserted first), or "oldest" - returns only the resource of
-                the hist list that was inserted last. Defaults to "single".
 
         Returns:
             Returns a hit in the form of the respective DTO model or None if no hit
             was found.
 
         Raises:
+            NoHitsFoundError:
+                If no hit was found.
             MultpleHitsFoundError:
-                Raised when obtaining more than one hit when using the "single" mode.
+                Raised when obtaining more than one hit.
         """
 
         hits = self.find_all(mapping=mapping)
 
         try:
             document = await hits.__anext__()
-        except StopAsyncIteration:
-            return None
+        except StopAsyncIteration as error:
+            raise NoHitsFoundError(mapping=mapping) from error
 
         try:
             _ = await hits.__anext__()

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 from hexkit.protocols.dao import (
     InvalidFindMappingError,
     MultipleHitsFoundError,
+    NoHitsFoundError,
     ResourceNotFoundError,
 )
 from hexkit.providers.mongodb.testutils import mongodb_fixture  # noqa: F401
@@ -247,8 +248,8 @@ async def test_dao_find_no_hits(
     )
     mapping = {"field_c": 28}
 
-    resource = await dao.find_one(mapping=mapping)
-    assert resource is None
+    with pytest.raises(NoHitsFoundError):
+        _ = await dao.find_one(mapping=mapping)
 
     resources = [hit async for hit in dao.find_all(mapping=mapping)]
     assert len(resources) == 0


### PR DESCRIPTION
```
The find_one method of DAOs now raises and exception instead of returning None when no hit was found.

Bumps version to 0.6.0.

Co-authored-by: Christoph Zwerschke <cito@online.de>
```