### PR TITLE
Moved part size calculation code from chassis lib

### DIFF
--- a/hexkit/__init__.py
+++ b/hexkit/__init__.py
@@ -15,4 +15,4 @@
 
 """A Toolkit for Building Microservices using the Hexagonal Architecture"""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,6 +17,7 @@
 """Test functionality in the utils package."""
 
 from collections.abc import Collection
+from contextlib import nullcontext
 
 import pytest
 from pydantic import BaseModel
@@ -24,9 +25,38 @@ from pydantic import BaseModel
 from hexkit.utils import (
     FieldNotInModelError,
     NonAsciiStrError,
+    calc_part_size,
     check_ascii,
     validate_fields_in_model,
 )
+
+MiB = 1024**2
+GiB = 1024**3
+TiB = 1024**4
+
+
+@pytest.mark.parametrize(
+    "preferred_part_size, file_size, expected_part_size",
+    [
+        (16 * MiB, 10 * GiB, 16 * MiB),
+        (16 * MiB, 200 * GiB, 32 * MiB),
+        (4 * MiB, 10 * GiB, 8 * MiB),
+        (6 * GiB, 10 * GiB, 4 * GiB),
+        (16 * MiB, 10 * TiB, None),
+        (None, 20 * MiB, 8 * MiB),
+        (None, 10 * GiB, 8 * MiB),
+        (None, 200 * GiB, 32 * MiB),
+    ],
+)
+def test_calc_part_size(
+    preferred_part_size: int, file_size: int, expected_part_size: int
+):
+    """Test code to dynamically adapt part size"""
+    with pytest.raises(ValueError) if file_size > 5 * TiB else nullcontext():  # type: ignore
+        adapted_part_size = calc_part_size(
+            preferred_part_size=preferred_part_size, file_size=file_size
+        )
+        assert adapted_part_size == expected_part_size
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
```
Added code to adapt part size dynamically:
1. Check if maximum file size (5 TiB) is exceeded and raise ValueError if so
2. Clamp input part size to our lower bound (8 MiB) and upper bound (4 GiB)
3. Adjust part sizes to next fitting power of two, if more than 10.000 parts would be produced

Co-authored-by: KerstenBreuer <kersten-breuer@outlook.com>
```