### PR TITLE
Bump requests, add types-requests, remove mypy-ext

### DIFF
--- a/hexkit/__init__.py
+++ b/hexkit/__init__.py
@@ -15,4 +15,4 @@
 
 """A Toolkit for Building Microservices using the Hexagonal Architecture"""
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,6 @@ dev =
     pytest-asyncio==0.18.3
     pytest-cov==3.0.0
     mypy==0.981
-    mypy-extensions==0.4.3
     pylint==2.13.3
     click==8.1.2
     black==22.3.0
@@ -69,7 +68,8 @@ dev =
     isort==5.10.1
     bandit==1.7.4
     pre-commit==2.17.0
-    requests==2.27.1
+    requests==2.28.1
+    types-requests==2.28.11.1
     mkdocs==1.3.0
     mkdocs-autorefs==0.4.1
     mkdocs-material==8.2.8


### PR DESCRIPTION
- update version of the requests library and add types-requests
- mypy-extensions is not needed since we require Python 3.9