### PR TITLE
Add a JWT based auth context provider

### DIFF
--- a/.static_files_ignore
+++ b/.static_files_ignore
@@ -4,6 +4,7 @@
 .github/workflows/check_config_docs.yaml
 
 scripts/update_config_docs.py
+scripts/license_checker.py
 
 example_data/README.md
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,3 +43,29 @@ Now open another terminal (ideally side by side to the old one) and run the clie
 ### Testing:
 The [stream calc test](./stream_calc/sc_tests/) suite demonstrates how to use the
 hexkit utilities to test a relying service.
+
+## Auth Demo
+
+This is a REST API that protects several methods in a simple core application
+using JSON web tokens for authentication and authorization. Run the API as follows:
+
+```bash
+cd auth_demo
+pip install -r requirements.txt
+python -m auth_demo
+```
+
+To check out the API, visit the endpoint http://127.0.0.1:8000/users to get some
+tokens for users that can be used with the following other endpoints:
+
+- status: check the login status and expiry date of the token
+- reception: show a welcome message to authenticated and non-authenticated users
+- lobby: require login as a user and show a welcome message
+- lounge: require login as a VIP user and show a different welcome message
+
+To login using the token, you can use the "Authorize" button under
+http://127.0.0.1:8000/docs - simply paste on of the bearer tokens here.
+Then use the "Try it out" button with the different endpoints. When you're
+not logged in, and authentication is required, you will get a "Forbidden" error.
+Of course, in a real world application, the user tokens would not be made
+freely available, but e.g. derived from an OpenID Connect login.

--- a/examples/auth_demo/auth_demo/__init__.py
+++ b/examples/auth_demo/auth_demo/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Christoph Zwerschke
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A simple REST API using token based authentication and authorization.
+"""

--- a/examples/auth_demo/auth_demo/__init__.py
+++ b/examples/auth_demo/auth_demo/__init__.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Christoph Zwerschke
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 """A simple REST API using token based authentication and authorization.
 """

--- a/examples/auth_demo/auth_demo/__main__.py
+++ b/examples/auth_demo/auth_demo/__main__.py
@@ -1,0 +1,22 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Main entry point of the package."""
+
+from auth_demo.main import run
+
+if __name__ == "__main__":
+    run()

--- a/examples/auth_demo/auth_demo/auth/__init__.py
+++ b/examples/auth_demo/auth_demo/auth/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Configuration and connector for the auth context."""

--- a/examples/auth_demo/auth_demo/auth/config.py
+++ b/examples/auth_demo/auth_demo/auth/config.py
@@ -1,0 +1,47 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Configuration of the auth context."""
+
+__all__ = ["AuthContext", "AuthConfig"]
+
+from datetime import datetime
+from typing import Any
+
+from auth_demo.util import generate_jwk
+from pydantic import BaseModel, Field
+
+from hexkit.providers.jwtauth import JWTAuthConfig
+
+
+class AuthContext(BaseModel):
+    """Example auth context."""
+
+    name: str = Field(..., description="The name of the user")
+    expires: datetime = Field(..., description="The expiration date of this context")
+    is_vip: bool = Field(False, description="Whether the user is a VIP")
+
+
+# create a key pair for signing and validating JSON web tokens
+AUTH_KEY_PAIR = generate_jwk()
+
+
+class AuthConfig(JWTAuthConfig):
+    """Config parameters and their defaults for the example auth conftext."""
+
+    auth_key = AUTH_KEY_PAIR.export(private_key=False)
+    auth_check_claims: dict[str, Any] = {"name": None, "exp": None}
+    auth_map_claims: dict[str, str] = {"exp": "expires"}

--- a/examples/auth_demo/auth_demo/auth/connector.py
+++ b/examples/auth_demo/auth_demo/auth/connector.py
@@ -26,7 +26,7 @@ from fastapi.exceptions import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.status import HTTP_403_FORBIDDEN
 
-from hexkit.protocols.auth import AuthContextError, AuthContextProtocol
+from hexkit.protocols.auth import AuthContextProtocol
 
 __all__ = ["AuthContext", "get_auth", "require_auth", "require_vip"]
 
@@ -47,7 +47,7 @@ async def get_auth_token(
         return None
     try:
         return await auth_provider.get_context(token)
-    except AuthContextError as exc:
+    except AuthContextProtocol.AuthContextError as exc:
         raise HTTPException(
             status_code=HTTP_403_FORBIDDEN,
             detail="Invalid authentication credentials",
@@ -80,8 +80,8 @@ def get_require_auth_token(vip_only: bool = False):
         try:
             context = await auth_provider.get_context(token)
             if not context:
-                raise AuthContextError("Not authenticated")
-        except AuthContextError as exc:
+                raise AuthContextProtocol.AuthContextError("Not authenticated")
+        except AuthContextProtocol.AuthContextError as exc:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN,
                 detail="Invalid authentication credentials",

--- a/examples/auth_demo/auth_demo/auth/connector.py
+++ b/examples/auth_demo/auth_demo/auth/connector.py
@@ -1,0 +1,102 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Connector for using the AuthContext provider with FastAPI."""
+
+from typing import Optional
+
+from auth_demo.auth.config import AuthContext
+from auth_demo.container import Container  # type: ignore
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, Security
+from fastapi.exceptions import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from starlette.status import HTTP_403_FORBIDDEN
+
+from hexkit.protocols.auth import AuthContextError, AuthContextProtocol
+
+__all__ = ["AuthContext", "get_auth", "require_auth", "require_vip"]
+
+
+@inject
+async def get_auth_token(
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=False)),
+    auth_provider: AuthContextProtocol[AuthContext] = Depends(
+        Provide[Container.auth_provider]
+    ),
+) -> Optional[AuthContext]:
+    """Get an authentication and authorization context using FastAPI.
+
+    Unauthenticated access is allowed and will return None as auth context.
+    """
+    token = credentials.credentials if credentials else None
+    if not token:
+        return None
+    try:
+        return await auth_provider.get_context(token)
+    except AuthContextError as exc:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="Invalid authentication credentials",
+        ) from exc
+
+
+def get_require_auth_token(vip_only: bool = False):
+    """Get a function that retrieves an authentication and authorization context
+
+    Unauthentication access is not allowed and will raise a "Forbidden" error.
+    VIP status can be required with the optional "vip_only" flag.
+    """
+
+    @inject
+    async def require_auth_token(
+        credentials: HTTPAuthorizationCredentials = Depends(
+            HTTPBearer(auto_error=True)
+        ),
+        auth_provider: AuthContextProtocol[AuthContext] = Depends(
+            Provide[Container.auth_provider]
+        ),
+    ) -> AuthContext:
+        """Get an authentication and authorization context using FastAPI."""
+
+        token = credentials.credentials if credentials else None
+        if not token:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN, detail="Not authenticated"
+            )
+        try:
+            context = await auth_provider.get_context(token)
+            if not context:
+                raise AuthContextError("Not authenticated")
+        except AuthContextError as exc:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail="Invalid authentication credentials",
+            ) from exc
+        if vip_only and not context.is_vip:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN, detail="Only VIPs are authorized here"
+            )
+        return context
+
+    return require_auth_token
+
+
+get_auth = Security(get_auth_token)
+
+require_auth = Security(get_require_auth_token())
+
+require_vip = Security(get_require_auth_token(vip_only=True))

--- a/examples/auth_demo/auth_demo/auth/connector.py
+++ b/examples/auth_demo/auth_demo/auth/connector.py
@@ -47,11 +47,11 @@ async def get_auth_token(
         return None
     try:
         return await auth_provider.get_context(token)
-    except AuthContextProtocol.AuthContextError as exc:
+    except AuthContextProtocol.AuthContextError as error:
         raise HTTPException(
             status_code=HTTP_403_FORBIDDEN,
             detail="Invalid authentication credentials",
-        ) from exc
+        ) from error
 
 
 def get_require_auth_token(vip_only: bool = False):
@@ -81,11 +81,11 @@ def get_require_auth_token(vip_only: bool = False):
             context = await auth_provider.get_context(token)
             if not context:
                 raise auth_provider.AuthContextError("Not authenticated")
-        except auth_provider.AuthContextError as exc:
+        except auth_provider.AuthContextError as error:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN,
                 detail="Invalid authentication credentials",
-            ) from exc
+            ) from error
         if vip_only and not context.is_vip:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN, detail="Only VIPs are authorized here"

--- a/examples/auth_demo/auth_demo/auth/connector.py
+++ b/examples/auth_demo/auth_demo/auth/connector.py
@@ -80,8 +80,8 @@ def get_require_auth_token(vip_only: bool = False):
         try:
             context = await auth_provider.get_context(token)
             if not context:
-                raise AuthContextProtocol.AuthContextError("Not authenticated")
-        except AuthContextProtocol.AuthContextError as exc:
+                raise auth_provider.AuthContextError("Not authenticated")
+        except auth_provider.AuthContextError as exc:
             raise HTTPException(
                 status_code=HTTP_403_FORBIDDEN,
                 detail="Invalid authentication credentials",

--- a/examples/auth_demo/auth_demo/config.py
+++ b/examples/auth_demo/auth_demo/config.py
@@ -1,0 +1,24 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Config parameters."""
+
+from auth_demo.auth.config import AuthConfig
+from auth_demo.core import HangoutConfig
+
+
+class Config(HangoutConfig, AuthConfig):
+    """Config parameters and their defaults."""

--- a/examples/auth_demo/auth_demo/container.py
+++ b/examples/auth_demo/auth_demo/container.py
@@ -1,0 +1,43 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# When mypy is started from pre-commit, it exits with an exception when analysing this
+# file without useful error message, thus ignoring.
+# (Please note this does not occur when running mypy directly.)
+#  type: ignore
+
+"""Module hosting the dependency injection container."""
+
+from auth_demo.auth.config import AuthContext
+from auth_demo.config import Config
+from auth_demo.core import Hangout
+
+from hexkit.inject import ContainerBase, get_configurator, get_constructor
+from hexkit.providers.jwtauth import JWTAuthContextProvider
+
+__all__ = ["Container"]
+
+
+class Container(ContainerBase):
+    """DI Container"""
+
+    config = get_configurator(Config)
+
+    hangout = get_constructor(Hangout, config=config)
+
+    auth_provider = get_constructor(
+        JWTAuthContextProvider, config=config, context_class=AuthContext
+    )

--- a/examples/auth_demo/auth_demo/core/__init__.py
+++ b/examples/auth_demo/auth_demo/core/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Application core."""
+
+from .hangout import Hangout, HangoutConfig
+
+__all__ = ["Hangout", "HangoutConfig"]

--- a/examples/auth_demo/auth_demo/core/hangout.py
+++ b/examples/auth_demo/auth_demo/core/hangout.py
@@ -1,0 +1,53 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""The core app with some protected methods."""
+
+from typing import Optional
+
+from auth_demo.ports.hangout import HangoutPort
+from pydantic import BaseSettings, Field
+
+__all__ = ["Hangout", "HangoutConfig"]
+
+
+class HangoutConfig(BaseSettings):
+    """Config parameters needed for the demo application."""
+
+    greeting: str = Field("Hello", description="How users shall be greeted")
+    treat: str = Field("beer", description="What VIPs should be offered")
+
+
+class Hangout(HangoutPort):
+    """Demo application that just shows personalized welcome messages."""
+
+    def __init__(self, *, config: HangoutConfig):
+        """Configure relevant ports."""
+        self._greeting = config.greeting
+        self._treat = config.treat
+
+    async def reception(self, name: Optional[str] = None) -> str:
+        """A method that is not protected at all."""
+        name = name or "anonymous user"
+        return f"{self._greeting}, {name}!"
+
+    async def lobby(self, name: str) -> str:
+        """A method that can be accessed only by authenticated users."""
+        return f"{self._greeting}, {name}!"
+
+    async def lounge(self, name: str) -> str:
+        """A method that can be accessed only by VIP users."""
+        return f"{self._greeting}, dear {name}, have a {self._treat}!"

--- a/examples/auth_demo/auth_demo/main.py
+++ b/examples/auth_demo/auth_demo/main.py
@@ -1,0 +1,56 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Implement global logic for running the application."""
+
+import asyncio
+
+import uvicorn
+from auth_demo.config import Config
+from auth_demo.container import Container  # type: ignore
+from auth_demo.router import router
+from fastapi import FastAPI
+from httpyexpect.server.handlers.fastapi_ import configure_exception_handler
+
+
+def get_configured_container(config: Config) -> Container:
+    """Create and configure the DI container."""
+    container = Container()
+    container.config.load_config(config)
+    return container
+
+
+def get_app() -> FastAPI:
+    """Create a FastAPI app."""
+    app = FastAPI()
+    app.include_router(router)
+    configure_exception_handler(app)
+    return app
+
+
+async def run_server():
+    """Run the HTTP API."""
+    config = Config()
+    async with get_configured_container(config) as container:
+        container.wire(modules=["auth_demo.router", "auth_demo.auth.connector"])
+        uv_config = uvicorn.Config(app=get_app())
+        server = uvicorn.Server(uv_config)
+        await server.serve()
+
+
+def run():
+    """Main entry point for running the server."""
+    asyncio.run(run_server())

--- a/examples/auth_demo/auth_demo/ports/__init__.py
+++ b/examples/auth_demo/auth_demo/ports/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""All inbound and outbound ports of the application."""

--- a/examples/auth_demo/auth_demo/ports/hangout.py
+++ b/examples/auth_demo/auth_demo/ports/hangout.py
@@ -1,0 +1,39 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""An inbound port for the demo application."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+
+class HangoutPort(ABC):
+    """An inbound port for a demo application showing personalized welcome messages."""
+
+    @abstractmethod
+    async def reception(self, name: Optional[str] = None) -> str:
+        """A method that is not protected at all."""
+        ...
+
+    @abstractmethod
+    async def lobby(self, name: str) -> str:
+        """A method that can be accessed only by authenticated users."""
+        ...
+
+    @abstractmethod
+    async def lounge(self, name: str) -> str:
+        """A method that can be accessed only by VIP users."""
+        ...

--- a/examples/auth_demo/auth_demo/router.py
+++ b/examples/auth_demo/auth_demo/router.py
@@ -1,0 +1,81 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""FastAPI router for the example application."""
+
+from auth_demo.auth.connector import AuthContext, get_auth, require_auth, require_vip
+from auth_demo.container import Container  # type: ignore
+from auth_demo.ports.hangout import HangoutPort
+from auth_demo.users import create_example_users
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends
+
+provide_hangout = Depends(Provide[Container.hangout])
+
+router = APIRouter()
+
+
+@router.get("/")
+async def root():
+    """Return a welcome message for testing."""
+    return {
+        "message": "Hello, world!",
+        "endpoints": ["docs", "users", "status", "reception", "lobby", "lounge"],
+    }
+
+
+@router.get("/users")
+async def users():
+    """Return a list of users with tokens for testing."""
+    return create_example_users()
+
+
+@router.get("/status")
+@inject
+async def status(
+    auth_context: AuthContext = get_auth,
+):
+    """This endpoint shows the current login status."""
+    expires = auth_context.expires.ctime() if auth_context else None
+    return {"status": f"logged in until {expires}" if expires else "logged out"}
+
+
+@router.get("/reception")
+@inject
+async def reception(
+    auth_context: AuthContext = get_auth, hangout: HangoutPort = provide_hangout
+):
+    """This endpoint is freely available, but personalized."""
+    name = auth_context.name if auth_context else None
+    return {"message": await hangout.reception(name)}
+
+
+@router.get("/lobby")
+@inject
+async def protected(
+    auth_context: AuthContext = require_auth, hangout: HangoutPort = provide_hangout
+):
+    """This endpoint requires authentication."""
+    return {"message": await hangout.lobby(auth_context.name)}
+
+
+@router.get("/lounge")
+@inject
+async def admin(
+    auth_context: AuthContext = require_vip, hangout: HangoutPort = provide_hangout
+):
+    """This endpoint requires VIP status."""
+    return {"message": await hangout.lounge(auth_context.name)}

--- a/examples/auth_demo/auth_demo/users.py
+++ b/examples/auth_demo/auth_demo/users.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Christoph Zwerschke
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Create access tokens for testing."""
+
+from datetime import datetime
+from typing import NamedTuple
+
+from auth_demo.auth.config import AUTH_KEY_PAIR
+from jwcrypto import jwt
+
+
+class UserInfo(NamedTuple):
+    """Basic user info"""
+
+    name: str
+    is_vip: bool
+
+
+EXAMPLE_USERS: list[UserInfo] = [
+    UserInfo("Ada Lovelace", False),
+    UserInfo("Grace Hopper", True),
+    UserInfo("Charles Babbage", False),
+    UserInfo("Alan Turin", True),
+]
+
+
+def create_token(user: UserInfo) -> str:
+    """Create an auth token that can be used for testing."""
+    key = AUTH_KEY_PAIR
+    header = {"alg": "ES256"}
+    iat = int(datetime.now().timestamp())
+    exp = iat + 60 * 10  # valid for 10 minutes
+    claims = {**user._asdict(), "iat": iat, "exp": exp}
+    token = jwt.JWT(header=header, claims=claims)
+    token.make_signed_token(key)
+    return token.serialize()
+
+
+def create_example_users():
+    """Create a couple of example users for the application."""
+    return {
+        "users": [
+            {**user._asdict(), "token": create_token(user)} for user in EXAMPLE_USERS
+        ]
+    }

--- a/examples/auth_demo/auth_demo/users.py
+++ b/examples/auth_demo/auth_demo/users.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Christoph Zwerschke
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 """Create access tokens for testing."""
 

--- a/examples/auth_demo/auth_demo/util/__init__.py
+++ b/examples/auth_demo/auth_demo/util/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Utility functions."""
+
+from .keys import generate_jwk
+
+__all__ = ["generate_jwk"]

--- a/examples/auth_demo/auth_demo/util/keys.py
+++ b/examples/auth_demo/auth_demo/util/keys.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Christoph Zwerschke
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Signing key generation"""
+
+from jwcrypto import jwk
+
+__all__ = ["generate_jwk"]
+
+
+def generate_jwk() -> jwk.JWK:
+    """Generate a random EC based JWK."""
+    return jwk.JWK.generate(kty="EC", crv="P-256")

--- a/examples/auth_demo/auth_demo/util/keys.py
+++ b/examples/auth_demo/auth_demo/util/keys.py
@@ -1,4 +1,5 @@
-# Copyright 2023 Christoph Zwerschke
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 """Signing key generation"""
 

--- a/examples/auth_demo/requirements.txt
+++ b/examples/auth_demo/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.92.0
+uvicorn==0.20.0
+httpyexpect==0.2.4

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -102,14 +102,14 @@ class AsyncConstructor(dependency_injector.providers.Resource):
 
             else:
                 raise NotConstructableError(
-                    "Callable attribute `construct` of AsyncContextConstructable class must"
-                    + " return an async context manager."
+                    "Callable attribute `construct` of AsyncContextConstructable class"
+                    + f" {constructable.__name__} must return an async context manager."
                 )
 
         return resource
 
     # This pylint error is inherited from the dependency_injector framework, other
-    # DI providers use the same basic signitature:
+    # DI providers use the same basic signature:
     # pylint: disable=keyword-arg-before-vararg
     def __init__(
         self,
@@ -155,12 +155,13 @@ class CMDynamicContainer(dependency_injector.containers.DynamicContainer):
 
         init_future = self.init_resources()
 
-        if not inspect.isawaitable(init_future):
-            raise AsyncInitShutdownError(
-                "Container does not support async initialization of resources."
-            )
+        if init_future:
+            if not inspect.isawaitable(init_future):
+                raise AsyncInitShutdownError(
+                    "Container does not support async initialization of resources."
+                )
+            await init_future
 
-        await init_future
         return self
 
     async def __aexit__(self, exc_type, exc_value, exc_trace):
@@ -168,12 +169,12 @@ class CMDynamicContainer(dependency_injector.containers.DynamicContainer):
 
         shutdown_future = self.shutdown_resources()
 
-        if not inspect.isawaitable(shutdown_future):
-            raise AsyncInitShutdownError(
-                "Container does not support async shutdown of resources."
-            )
-
-        await shutdown_future
+        if shutdown_future:
+            if not inspect.isawaitable(shutdown_future):
+                raise AsyncInitShutdownError(
+                    "Container does not support async shutdown of resources."
+                )
+            await shutdown_future
 
 
 SELF = TypeVar("SELF")

--- a/hexkit/inject.py
+++ b/hexkit/inject.py
@@ -155,13 +155,12 @@ class CMDynamicContainer(dependency_injector.containers.DynamicContainer):
 
         init_future = self.init_resources()
 
-        if init_future:
-            if not inspect.isawaitable(init_future):
-                raise AsyncInitShutdownError(
-                    "Container does not support async initialization of resources."
-                )
-            await init_future
+        if not inspect.isawaitable(init_future):
+            raise AsyncInitShutdownError(
+                "Container does not support async initialization of resources."
+            )
 
+        await init_future
         return self
 
     async def __aexit__(self, exc_type, exc_value, exc_trace):
@@ -169,12 +168,12 @@ class CMDynamicContainer(dependency_injector.containers.DynamicContainer):
 
         shutdown_future = self.shutdown_resources()
 
-        if shutdown_future:
-            if not inspect.isawaitable(shutdown_future):
-                raise AsyncInitShutdownError(
-                    "Container does not support async shutdown of resources."
-                )
-            await shutdown_future
+        if not inspect.isawaitable(shutdown_future):
+            raise AsyncInitShutdownError(
+                "Container does not support async shutdown of resources."
+            )
+
+        await shutdown_future
 
 
 SELF = TypeVar("SELF")

--- a/hexkit/protocols/auth.py
+++ b/hexkit/protocols/auth.py
@@ -20,20 +20,7 @@ from typing import Optional, Protocol, TypeVar
 
 from pydantic import BaseModel
 
-__all__ = [
-    "AuthContext_co",
-    "AuthContextProtocol",
-    "AuthContextError",
-    "AuthContextValidationError",
-]
-
-
-class AuthContextError(RuntimeError):
-    """Error when retrieving the authentication and authorization context failed."""
-
-
-class AuthContextValidationError(RuntimeError):
-    """Error that is raised when the underlying token is invalid."""
+__all__ = ["AuthContext_co", "AuthContextProtocol"]
 
 
 # type variable for handling different kinds of auth contexts
@@ -42,6 +29,12 @@ AuthContext_co = TypeVar("AuthContext_co", bound=BaseModel, covariant=True)
 
 class AuthContextProtocol(Protocol[AuthContext_co]):
     """A protocol for retrieving an authentication and authorization context."""
+
+    class AuthContextError(RuntimeError):
+        """Error when retrieving the authentication and authorization context failed."""
+
+    class AuthContextValidationError(RuntimeError):
+        """Error that is raised when the underlying token is invalid."""
 
     async def get_context(self, token: str) -> Optional[AuthContext_co]:
         """Derive an authentication and authorization context from a token.

--- a/hexkit/protocols/auth.py
+++ b/hexkit/protocols/auth.py
@@ -1,0 +1,56 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Protocol for retrieving a context for authentication and authorization."""
+
+from typing import Optional, Protocol, TypeVar
+
+from pydantic import BaseModel
+
+__all__ = [
+    "AuthContext_co",
+    "AuthContextProtocol",
+    "AuthContextError",
+    "AuthContextValidationError",
+]
+
+
+class AuthContextError(RuntimeError):
+    """Error when retrieving the authentication and authorization context failed."""
+
+
+class AuthContextValidationError(RuntimeError):
+    """Error that is raised when the underlying token is invalid."""
+
+
+# type variable for handling different kinds of auth contexts
+AuthContext_co = TypeVar("AuthContext_co", bound=BaseModel, covariant=True)
+
+
+class AuthContextProtocol(Protocol[AuthContext_co]):
+    """A protocol for retrieving an authentication and authorization context."""
+
+    async def get_context(self, token: str) -> Optional[AuthContext_co]:
+        """Derive an authentication and authorization context from a token.
+
+        The protocol is independent of the underlying serialization format.
+
+        Raises an AuthContextValidationError if the provided token cannot
+        establish a valid authentication and authorization context.
+
+        Calling this may involve fetching public keys or other data over the network.
+        """
+        ...

--- a/hexkit/providers/jwtauth/__init__.py
+++ b/hexkit/providers/jwtauth/__init__.py
@@ -16,16 +16,6 @@
 
 """Subpackage containing a token based authentication context provider."""
 
-from .provider import (
-    JWTAuthConfig,
-    JWTAuthConfigError,
-    JWTAuthContextProvider,
-    JWTAuthValidationError,
-)
+from .provider import JWTAuthConfig, JWTAuthContextProvider
 
-__all__ = [
-    "JWTAuthContextProvider",
-    "JWTAuthConfig",
-    "JWTAuthConfigError",
-    "JWTAuthValidationError",
-]
+__all__ = ["JWTAuthConfig", "JWTAuthContextProvider"]

--- a/hexkit/providers/jwtauth/__init__.py
+++ b/hexkit/providers/jwtauth/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Subpackage containing a token based authentication context provider."""
+
+from .provider import (
+    JWTAuthConfig,
+    JWTAuthConfigError,
+    JWTAuthContextProvider,
+    JWTAuthValidationError,
+)
+
+__all__ = [
+    "JWTAuthContextProvider",
+    "JWTAuthConfig",
+    "JWTAuthConfigError",
+    "JWTAuthValidationError",
+]

--- a/hexkit/providers/jwtauth/provider.py
+++ b/hexkit/providers/jwtauth/provider.py
@@ -99,7 +99,6 @@ class JWTAuthContextProvider(AuthContextProtocol[AuthContext_co]):
             if attribute is not None:
                 claims[attribute] = value
         try:
-            claims["expires"] = "Indemann"
             return self._context_class(**claims)
         except ValidationError as error:
             raise self.AuthContextValidationError(

--- a/hexkit/providers/jwtauth/provider.py
+++ b/hexkit/providers/jwtauth/provider.py
@@ -1,0 +1,159 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""JSON web token based provider implementing the AuthContextProtocol."""
+
+import json
+from typing import Any, Optional
+
+from jwcrypto import jwk, jwt
+from jwcrypto.common import JWException
+from pydantic import BaseSettings, Field, ValidationError
+
+from hexkit.custom_types import JsonObject
+from hexkit.protocols.auth import (
+    AuthContext_co,
+    AuthContextError,
+    AuthContextProtocol,
+    AuthContextValidationError,
+)
+
+__all__ = [
+    "JWTAuthConfig",
+    "JWTAuthConfigError",
+    "JWTAuthError",
+    "JWTAuthValidationError",
+    "JWTAuthContextProvider",
+]
+
+
+class JWTAuthError(AuthContextError):
+    """Error in JSON web token based authentication and authorization"""
+
+
+class JWTAuthValidationError(JWTAuthError, AuthContextValidationError):
+    """Error when validating the JSON web token"""
+
+
+class JWTAuthConfigError(JWTAuthError):
+    """Error in auth-specific config params"""
+
+
+class JWTAuthConfig(BaseSettings):
+    """JWT based auth specific config params.
+
+    Inherit your config class from this class if you need
+    JWT based authentication in the backend.
+    """
+
+    auth_key: dict[str, str] = Field(
+        ...,
+        example={"crv": "P-256", "kty": "EC", "x": "...", "y": "..."},
+        description="The public key for validating the token signature.",
+    )
+    auth_algs: list[str] = Field(
+        ["ES256", "RS256"],
+        description="A list of all algorithms that can be used for signing tokens.",
+    )
+    auth_check_claims: dict[str, Any] = Field(
+        dict.fromkeys("name email iat exp".split()),
+        description="A dict of all claims that shall be verified by the provider."
+        + " A value of None means that the claim can have any value.",
+    )
+    auth_map_claims: dict[str, str] = Field(
+        {},
+        description="A mapping of claims to attributes in the auth context."
+        + " Only differently named attributes must be specified."
+        + " The value None can be used to exclude claims from the auth context.",
+    )
+
+
+class JWTAuthContextProvider(AuthContextProtocol[AuthContext_co]):
+    """A JWT based provider implementing the AuthContextProtocol."""
+
+    def __init__(self, *, config: JWTAuthConfig, context_class: type[AuthContext_co]):
+        """Initialize the provider with the given configuration.
+
+        Raises a JWTAuthConfigError if the configuration is invalid.
+        """
+        try:
+            key = jwk.JWK.from_json(config.auth_key)
+            if not key.has_public:
+                raise ValueError("No public key found.")
+            if key.has_private:
+                raise ValueError("Private key found, this should not be added here.")
+        except Exception as exc:
+            raise JWTAuthConfigError(
+                "No valid token signing key found in the configuration:" f" {exc}"
+            ) from exc
+        self._key = key
+        self._algs = config.auth_algs
+        self._check_claims = config.auth_check_claims
+        self._map_claims = config.auth_map_claims
+        self._context_class = context_class
+
+    async def get_context(self, token: str) -> Optional[AuthContext_co]:
+        """Get an authentication and authorization context from a token.
+
+        The token must be a serialized and signed JSON web token.
+
+        Raises an AuthContextValidationError if the provded token cannot
+        establish a valid authentication and authorization context.
+        """
+        claims = dict(self._decode_and_validate_token(token))
+        for claim, attribute in self._map_claims.items():
+            try:
+                value = claims.pop(claim)
+            except KeyError as exc:
+                raise JWTAuthValidationError(f"Missing claim {claim}") from exc
+            if attribute is not None:
+                claims[attribute] = value
+        try:
+            claims["expires"] = "Indemann"
+            return self._context_class(**claims)
+        except ValidationError as error:
+            raise JWTAuthValidationError(f"Invalid auth context: {error}") from error
+
+    def _decode_and_validate_token(self, token: str) -> JsonObject:
+        """Decode and validate the given JSON Web Token.
+
+        Returns the decoded claims in the token as a dictionary if valid.
+
+        Raises a JWTAuthValidationError if the token is invalid.
+        """
+        if not token:
+            raise JWTAuthValidationError("Empty token")
+        try:
+            jwt_token = jwt.JWT(
+                jwt=token,
+                key=self._key,
+                algs=self._algs,
+                check_claims=self._check_claims,
+                expected_type="JWS",
+            )
+        except (
+            JWException,
+            UnicodeDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise JWTAuthValidationError(f"Not a valid token: {exc}") from exc
+        try:
+            claims = json.loads(jwt_token.claims)
+        except json.JSONDecodeError as exc:
+            raise JWTAuthValidationError(f"Claims cannot be decoded: {exc}") from exc
+        return claims

--- a/hexkit/providers/jwtauth/provider.py
+++ b/hexkit/providers/jwtauth/provider.py
@@ -24,12 +24,7 @@ from jwcrypto.common import JWException
 from pydantic import BaseSettings, Field, ValidationError
 
 from hexkit.custom_types import JsonObject
-from hexkit.protocols.auth import (
-    AuthContext_co,
-    AuthContextError,
-    AuthContextProtocol,
-    AuthContextValidationError,
-)
+from hexkit.protocols.auth import AuthContext_co, AuthContextProtocol
 
 __all__ = [
     "JWTAuthConfig",
@@ -40,11 +35,13 @@ __all__ = [
 ]
 
 
-class JWTAuthError(AuthContextError):
+class JWTAuthError(AuthContextProtocol.AuthContextError):
     """Error in JSON web token based authentication and authorization"""
 
 
-class JWTAuthValidationError(JWTAuthError, AuthContextValidationError):
+class JWTAuthValidationError(
+    JWTAuthError, AuthContextProtocol.AuthContextValidationError
+):
     """Error when validating the JSON web token"""
 
 

--- a/hexkit/providers/jwtauth/provider.py
+++ b/hexkit/providers/jwtauth/provider.py
@@ -17,6 +17,7 @@
 """JSON web token based provider implementing the AuthContextProtocol."""
 
 import json
+from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 from jwcrypto import jwk, jwt
@@ -60,6 +61,19 @@ class JWTAuthConfig(BaseSettings):
 
 class JWTAuthContextProvider(AuthContextProtocol[AuthContext_co]):
     """A JWT based provider implementing the AuthContextProtocol."""
+
+    @classmethod
+    @asynccontextmanager
+    async def construct(
+        cls, *, config: JWTAuthConfig, context_class: type[AuthContext_co]
+    ):
+        """Make this usable as an async dependency.
+
+        Args:
+            config:
+                Config parameters needed for JWT validation and transformation.
+        """
+        yield cls(config=config, context_class=context_class)
 
     def __init__(self, *, config: JWTAuthConfig, context_class: type[AuthContext_co]):
         """Initialize the provider with the given configuration.

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -87,7 +87,12 @@ EXCLUDE_ENDINGS = [
 ]
 
 # exclude any files with names that match any of the following regex:
-EXCLUDE_PATTERN = [r".*\.egg-info.*", r".*__cache__.*", r".*\.git.*"]
+EXCLUDE_PATTERN = [
+    r".*\.egg-info.*",
+    r".*__cache__.*",
+    r".*\.git.*",
+    r".*/requirements\.txt$",
+]
 
 # The License header, "{year}" will be replaced by current year:
 COPYRIGHT_TEMPLATE = """Copyright {year} {author}

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ all =
     %(akafka)s
     %(s3)s
     %(mongodb)s
-    %(atoken)s
+    %(jwtauth)s
     %(dev)s
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,8 @@ s3 =
     botocore==1.29.50
 mongodb =
     motor==3.1.1
+jwtauth =
+    jwcrypto==1.4.2
 dev =
     pytest==7.2.1
     pytest-asyncio==0.20.3
@@ -83,6 +85,7 @@ all =
     %(akafka)s
     %(s3)s
     %(mongodb)s
+    %(atoken)s
     %(dev)s
 
 [options.packages.find]


### PR DESCRIPTION
Proposal for a univeral JWT auth context provider.

This PR includes an example app that shows how this can be used with FastAPI,
an how the provider and the app can be set up by injecting a configuration (or any other dependencies).

We may need to reconsider whether this really should be part of hexkit or put elsewhere,
since it is more like a utility than a provider in the sense of hexkit, and no translator either
(the auth.connector module could be considered the translator).

This still needs some unit tests for the provider and e2e tests for the demo applicaton.

Update: It was decided to move this to the ghga-service-commons library.