### PR TITLE
Enable ID in find_all() (GSI-190)

### DIFF
--- a/hexkit/providers/mongodb/provider.py
+++ b/hexkit/providers/mongodb/provider.py
@@ -226,6 +226,10 @@ class MongoDbDaoBase(ABC, Generic[Dto]):
 
         self._validate_find_mapping(mapping)
 
+        if self._id_field in mapping:
+            mapping = dict(mapping)
+            mapping["_id"] = mapping.pop(self._id_field)
+
         cursor = self._collection.find(filter=mapping, session=self._session)
 
         async for document in cursor:

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -82,6 +82,24 @@ async def test_dao_find_all_with_id(mongodb_fixture: MongoDbFixture):  # noqa: F
     no_results = [x async for x in dao.find_all(mapping={"id": "noresults"})]
     assert len(no_results) == 0
 
+    # make sure other fields beside ID aren't getting ignored
+    no_results_multifield = [
+        x
+        async for x in dao.find_all(
+            mapping={"id": resource_inserted.id, "field_b": 134293487}
+        )
+    ]
+    assert len(no_results_multifield) == 0
+
+    multifield_found = [
+        x
+        async for x in dao.find_all(
+            mapping={"id": resource_inserted.id, "field_b": resource_inserted.field_b}
+        )
+    ]
+    assert len(multifield_found) == 1
+    assert multifield_found[0] == resource_inserted
+
     # find_one calls find_all, so double check that it works there too
     result = await dao.find_one(mapping={"id": resource_inserted.id})
     assert result == resource_inserted

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -76,10 +76,15 @@ async def test_dao_find_all_with_id(mongodb_fixture: MongoDbFixture):  # noqa: F
         x async for x in dao.find_all(mapping={"id": resource_inserted.id})
     ]
     assert len(resources_read) == 1
+    assert resources_read[0].id == resource_inserted.id
 
     # make sure the previous check wasn't a false positive
     no_results = [x async for x in dao.find_all(mapping={"id": "noresults"})]
     assert len(no_results) == 0
+
+    # find_one calls find_all, so double check that it works there too
+    result = await dao.find_one(mapping={"id": resource_inserted.id})
+    assert result == resource_inserted
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
There was a problem with find_all() in the mongodb base DAO where you couldn't include a DTO's id in the mapping because you'd run into one of two problems:
1. You use the id field as it's labeled on the DTO and it doesn't match anything in the database because the ID fields are relabeled "_id" upon insertion.
2. You use "_id" in the mapping to get around the above issue, but this fails because the validation method sees that "_id" is not in the DTO schema. 

We can check the mapping that is passed in to find_all and, if `self._id_field` is present, make a copy of the mapping with the id field renamed to "_id". 