### PR TITLE
Package data configuration moved into MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/hexkit/providers/s3/test_files/*.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,3 @@ Repository = "https://github.com/ghga-de/hexkit"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-
-[tool.setuptools.package-data]
-"hexkit.providers.s3.test_files" = ["*.yaml"]


### PR DESCRIPTION
This PR moves package data configuration from pyproject.toml to MANIFEST.in file as mentioned here https://github.com/ghga-de/hexkit/pull/69#pullrequestreview-1706734818