### PR TITLE
Log all config (GSI-546)

### DIFF
--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -143,8 +143,11 @@ class RecordCompiler(StreamHandler):
 
 
 def configure_logging(*, config: LoggingConfig, logger: Optional[Logger] = None):
-    """Set up logging. Configures the root logger by default,
-    but can be used to configure a specific logger as well.
+    """Set up logging.
+
+    Configures the root logger by default, but can be used to configure a specific
+    logger as well. Will also log the complete configuration of the service with
+    secret values hidden.
     """
     formatter = Formatter(config.log_format) if config.log_format else JsonFormatter()
 
@@ -157,3 +160,8 @@ def configure_logging(*, config: LoggingConfig, logger: Optional[Logger] = None)
 
     logger.setLevel(config.log_level)
     logger.addHandler(handler)
+
+    logger.info(
+        "Logging configured, complete configuration in details",
+        extra=config.model_dump(mode="json"),
+    )

--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -147,7 +147,7 @@ def configure_logging(*, config: LoggingConfig, logger: Optional[Logger] = None)
 
     Configures the root logger by default, but can be used to configure a specific
     logger as well. Will also log the complete configuration of the service with
-    secret values hidden.
+    secret values hidden, if it's passed to this function and inherits from LoggingConfig.
     """
     formatter = Formatter(config.log_format) if config.log_format else JsonFormatter()
 


### PR DESCRIPTION
Adds a statement at the end of  `configure_logging()` to log the complete configuration via the details section of the message.
Since there's a potential to leak secrets should something change, I added a test to make sure the secrets are hidden by pydantic when dumped. 