### PR TITLE
Update pypi publish

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -18,17 +18,8 @@ jobs:
 
       - name: Ensure package version and tag are equal
         run: |
-          if [ -f "setup.py" ]
-          then
-            PKG_VER="$(python setup.py --version)"
-          elif [ -f "pyproject.toml" ]
-          then
-            version=$(python3 -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
-            PKG_VER=$version
-          else
-            echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1
-          fi
 
+          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
 
           echo "Package version is $PKG_VER" >&2

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -16,10 +16,24 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Verify Package Version vs Tag Version
+      - name: Ensure package version and tag are equal
+        working-directory: ${{ inputs.working_directory }}
+        shell: bash
         run: |
-          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
-          TAG_VER="${GITHUB_REF##*/}"
+          if [ -f "setup.py" ]
+          then
+            PKG_VER="$(python setup.py --version)"
+          elif [ -f "pyproject.toml" ]
+          then
+            version=$(python3.11 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+            PKG_VER=$version
+          else
+            echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1
+          fi
+
+          TAG_VER=${{ inputs.package_version }}
+          [[ -z "$TAG_VER" ]] && TAG_VER=${{ inputs.tag }}
+
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2
           if [ "$PKG_VER" != "$TAG_VER" ]; then
@@ -46,7 +60,7 @@ jobs:
       - name: Install the newly build package with all extras
         run: |
           TAR_PATH="$( realpath ./dist/*.tar.gz)"
-          python -m \
+          python3 -m \
             pip install \
             "${TAR_PATH}[all]"
 
@@ -56,7 +70,7 @@ jobs:
           pip install
           -r requirements-dev.txt
 
-      - name: Run pytest on freshly installed package
+      - name: Run pytest on freshly install package
         run: |
           pytest .
 

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -17,8 +17,6 @@ jobs:
           python-version: "3.9"
 
       - name: Ensure package version and tag are equal
-        working-directory: ${{ inputs.working_directory }}
-        shell: bash
         run: |
           if [ -f "setup.py" ]
           then
@@ -31,8 +29,7 @@ jobs:
             echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1
           fi
 
-          TAG_VER=${{ inputs.package_version }}
-          [[ -z "$TAG_VER" ]] && TAG_VER=${{ inputs.tag }}
+          TAG_VER="${GITHUB_REF##*/}"
 
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -54,10 +54,10 @@ jobs:
           --outdir dist/
           .
 
-      - name: Install the newly build package with all extras
+      - name: Install the newly built package with all extras
         run: |
           TAR_PATH="$( realpath ./dist/*.tar.gz)"
-          python3 -m \
+          python -m \
             pip install \
             "${TAR_PATH}[all]"
 

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -25,7 +25,7 @@ jobs:
             PKG_VER="$(python setup.py --version)"
           elif [ -f "pyproject.toml" ]
           then
-            version=$(python3.11 -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+            version=$(python3 -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
             PKG_VER=$version
           else
             echo "Neither setup.py nor pyproject.toml were found." >&2; exit 1
@@ -70,7 +70,7 @@ jobs:
           pip install
           -r requirements-dev.txt
 
-      - name: Run pytest on freshly install package
+      - name: Run pytest on freshly installed package
         run: |
           pytest .
 


### PR DESCRIPTION
The line `PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"` was became broken when we added the tooling config to pyproject.toml because the regex then matched on `target-version = "py39"` (for ruff) as well as `minversion = "7.1"` (for pytest).

To fix this, I've added `^` before `version` so it will only match the desired line. 