### PR TITLE
Reference requirements in lock folder 

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -56,7 +56,7 @@ jobs:
         run: >-
           python -m
           pip install
-          -r requirements-dev.txt
+          --no-deps -r ./lock/requirements-dev.txt
 
       - name: Run pytest on freshly installed package
         run: |


### PR DESCRIPTION
Reference to the requirements-dev.txt file was out of date, now that the file has been moved to /lock.