### PR TITLE
Consistent spelling of correlation ID in logs

### DIFF
--- a/src/hexkit/providers/akafka/provider.py
+++ b/src/hexkit/providers/akafka/provider.py
@@ -259,7 +259,7 @@ class KafkaEventPublisher(EventPublisherProtocol):
                 raise
 
             correlation_id = new_correlation_id()
-            logging.info("Generated new correlation id: %s", correlation_id)
+            logging.info("Generated new correlation ID: %s", correlation_id)
 
         validate_correlation_id(correlation_id)
 


### PR DESCRIPTION
When filtering out log messages about correlation IDs in an integration test, I was bitten by the fact that in one case a different spellings of "id" was used (lower instead upper case). The PR changes just this log message so make it easier to filter correlation ID related messages.