### PR TITLE
Test with Python 3.12 on GitHub

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
-# Copy install and launcher script
+# Copy install script
 COPY ./dev_install /bin
 
 # Install secondary Python version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,14 +1,29 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-bullseye
 
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT="3.9"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+ENV PYTHONUNBUFFERED 1
 
-# install dependencies:
-# (direct package dependencies are listed in the setup.py):
-# RUN apt install -y ...
+# Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
-# Copy install script to bin:
+# Copy install and launcher script
 COPY ./dev_install /bin
+
+# Install secondary Python version
+USER vscode
+RUN <<EOF
+curl -sS https://pyenv.run | /bin/sh
+INIT_PYENV='
+export PYENV_ROOT="$HOME/.pyenv"
+[ -d "$PYENV_ROOT/bin" ] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+'
+echo "$INIT_PYENV" >> ~/.profile
+echo "$INIT_PYENV" >> ~/.bashrc
+. ~/.profile
+pyenv install --skip-existing 3.12
+pyenv global system 3.12
+EOF
 
 CMD ["sleep", "infinity"]

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -3,23 +3,6 @@
 
 cd /workspace
 
-# install secondary Python version
-if ! [ -d "$HOME/.pyenv" ]
-then
-    curl -sS https://pyenv.run | /bin/sh
-    LOAD_PATH_INSTRUCTIONS='''
-export PYENV_ROOT="$HOME/.pyenv"
-[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
-'''
-    echo "$LOAD_PATH_INSTRUCTIONS" >> ~/.profile
-    echo "$LOAD_PATH_INSTRUCTIONS" >> ~/.bashrc
-    source ~/.profile
-    source ~/.bashrc
-fi
-pyenv install --skip-existing 3.12
-pyenv global system 3.12
-
 # upgrade pip
 python -m pip install --upgrade pip
 

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -3,10 +3,10 @@
 
 cd /workspace
 
-# install secondary python version:
+# install secondary Python version
 if ! [ -d "$HOME/.pyenv" ]
 then
-    curl https://pyenv.run | /bin/sh
+    curl -sS https://pyenv.run | /bin/sh
     LOAD_PATH_INSTRUCTIONS='''
 export PYENV_ROOT="$HOME/.pyenv"
 [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3-postgres
-// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6
+// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.12, 3.11, 3.10, 3.9
 {
 	"name": "${localWorkspaceFolderBasename}",
 	"dockerComposeFile": "docker-compose.yml",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     build:
@@ -7,7 +5,7 @@ services:
       dockerfile: ./Dockerfile
 
       args:
-        # [Choice] Python version: 3, 3.8, 3.7, 3.6
+        # [Choice] Python version: 3, 3.12, 3.11, 3.10, 3.9
         VARIANT: 3.9
 
     init: true

--- a/.devcontainer/license_header.txt
+++ b/.devcontainer/license_header.txt
@@ -1,4 +1,4 @@
-Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 for the German Human Genome-Phenome Archive (GHGA)
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -16,6 +16,8 @@ jobs:
       - name: Common steps
         id: common
         uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
       - name: Check pyproject.toml
         id: check-pyproject

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -1,16 +1,23 @@
-name: Check if the config schema and the example are up to date.
+name: Check if pyproject.toml file is up to date
 
 on: push
 
 jobs:
   static-code-analysis:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
 
-      - id: common
-        uses: ghga-de/gh-action-common@v4
+    name: Check pyproject file
+
+    steps:
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Common steps
+        id: common
+        uses: ghga-de/gh-action-common@v5
 
       - name: Check pyproject.toml
+        id: check-pyproject
         run: |
           ./scripts/update_pyproject.py --check

--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Check pyproject file
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -5,13 +5,22 @@ on: push
 jobs:
   check-template-files:
     runs-on: ubuntu-latest
+
+    name: Check template files
+
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        id: setup-python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.12'
+
       - name: Check template files
+        id: check-template-files
         run: |
           if [ "${{ github.event.repository.name }}" == "microservice-repository-template" ]
           then

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   check-template-files:
-    runs-on: ubuntu-latest
-
     name: Check template files
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -7,21 +7,24 @@ on:
 jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
+
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
 
-      - name: Ensure package version and tag are equal
+      - name: Ensure package version and tag name are equal
+        id: check-package
         run: |
-
           PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
-
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2
           if [ "$PKG_VER" != "$TAG_VER" ]; then
@@ -30,6 +33,7 @@ jobs:
           fi
 
       - name: Install pypa/build
+        id: install-build
         run: >-
           python -m
           pip install
@@ -37,6 +41,7 @@ jobs:
           --user
 
       - name: Build a binary wheel and a source tarball
+        id: build
         run: >-
           python -m
           build
@@ -45,7 +50,8 @@ jobs:
           --outdir dist/
           .
 
-      - name: Install the newly built package with all extras
+      - name: Install the newly build package with all extras
+        id: install
         run: |
           TAR_PATH="$( realpath ./dist/*.tar.gz)"
           python -m \
@@ -53,22 +59,26 @@ jobs:
             "${TAR_PATH}[all]"
 
       - name: Install testing requirements
+        id: install-dev
         run: >-
           python -m
           pip install
           --no-deps -r ./lock/requirements-dev.txt
 
       - name: Run pytest on freshly installed package
+        id: test
         run: |
           pytest .
 
       - name: Publish distribution package to PyPI (test)
+        id: publish-test
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution package to PyPI (production)
+        id: publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -5,23 +5,37 @@ on: push
 jobs:
   static-code-analysis:
     runs-on: ubuntu-latest
+
     name: Static Code Analysis
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
 
-      - id: common
-        uses: ghga-de/gh-action-common@v4
+      - name: Common steps
+        id: common
+        uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: '3.12'
 
-      - uses: pre-commit/action@v3.0.0
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
         env:
           SKIP: no-commit-to-branch
-      - name: ruff
+
+      - name: Run ruff
+        id: ruff
         run: |
           ruff check --output-format=github .
           ruff format --check .
-      - name: mypy
+
+      - name: Run mypy
+        id: mypy
         run: |
           mypy .
+
       - name: Check license header and file
+        id: license-checker
         run: |
           ./scripts/license_checker.py

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Static Code Analysis
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,27 +4,49 @@ on: push
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
     name: Tests
 
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12']
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        id: checkout
+        uses: actions/checkout@v4
 
-      - id: common
-        uses: ghga-de/gh-action-common@v4
+      - name: Common steps
+        id: common
+        uses: ghga-de/gh-action-common@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      - id: tox
+      - name: Install tox plugin
+        id: install-tox-gh-actions
+        run: |
+          pip install --disable-pip-version-check "tox-gh-actions>=3.2,<4"
+
+      - name: Run tests with Python ${{ matrix.python-version }}
+        id: pytest
+        if: ${{ matrix.python-version != '3.12' }}
         run: |
           export ${{ steps.common.outputs.CONFIG_YAML_ENV_VAR_NAME }}="${{ steps.common.outputs.CONFIG_YAML }}"
 
-          tox \
-            run \
-            -- \
-            --cov="${{ steps.common.outputs.PACKAGE_NAME }}" \
-            --cov-report=xml
+          tox
 
-      - id: coveralls
-        name: Upload coverage to coveralls
+      - name: Run tests with Python ${{ matrix.python-version }} measuring coverage
+        id: pytest-coverage
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          export ${{ steps.common.outputs.CONFIG_YAML_ENV_VAR_NAME }}="${{ steps.common.outputs.CONFIG_YAML }}"
+
+          tox -- --cov="${{ steps.common.outputs.PACKAGE_NAME }}" --cov-report=xml
+
+      - name: Upload coverage to coveralls
+        id: coveralls
+        if: ${{ matrix.python-version == '3.12' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,9 +2,9 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 default_language_version:
-  python: python3.9
+  python: python3.12
 
-minimum_pre_commit_version: 3.0.0
+minimum_pre_commit_version: 3.7.0
 
 repos:
   - repo: local

--- a/.pyproject_generation/README.md
+++ b/.pyproject_generation/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+ Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
  for the German Human Genome-Phenome Archive (GHGA)
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -26,16 +26,20 @@ Repository = "https://github.com/ghga-de/hexkit"
 [tool.tox]
 legacy_tox_ini = """
     [tox]
-    min_version = 4.0
-    env_list =
-        py39
-        py312
+    env_list = py3{9,12}
+
+    [gh-actions]
+    python =
+        3.9: py39
+        3.10: py310
+        3.11: py311
+        3.12: py312
 
     [testenv]
-    pass_env=
+    pass_env =
         TC_HOST
         DOCKER_HOST
     deps =
         --no-deps -r ./lock/requirements-dev.txt
-    commands = pytest ./tests {posargs}
+    commands = pytest {posargs}
 """

--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=67.7.2"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -100,7 +100,7 @@ check_untyped_defs = true
 no_site_packages = false
 
 [tool.pytest.ini_options]
-minversion = "7.1"
+minversion = "8.0"
 asyncio_mode = "strict"
 
 [tool.coverage.paths]

--- a/.template/README.md
+++ b/.template/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+ Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
  for the German Human Genome-Phenome Archive (GHGA)
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/.template/static_files_ignore.txt
+++ b/.template/static_files_ignore.txt
@@ -5,6 +5,7 @@
 .github/workflows/check_openapi_spec.yaml
 .github/workflows/check_readme.yaml
 .github/workflows/cd.yaml
+.github/workflows/static_code_analysis.yaml
 .github/workflows/tests.yaml
 .github/workflows/ci_release.yaml
 .github/workflows/ci_workflow_dispatch.yaml

--- a/.template/static_files_ignore.txt
+++ b/.template/static_files_ignore.txt
@@ -18,5 +18,4 @@ scripts/update_all.py
 example_data/README.md
 
 .devcontainer/Dockerfile
-.devcontainer/dev_install
 .readme_generation/README.md

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+   Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
    for the German Human Genome-Phenome Archive (GHGA)
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+ Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
  for the German Human Genome-Phenome Archive (GHGA)
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/__init__.py
+++ b/examples/stream_calc/sc_tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/integration/__init__.py
+++ b/examples/stream_calc/sc_tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/integration/test_cli.py
+++ b/examples/stream_calc/sc_tests/integration/test_cli.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/integration/test_event_api.py
+++ b/examples/stream_calc/sc_tests/integration/test_event_api.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/unit/__init__.py
+++ b/examples/stream_calc/sc_tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/unit/test_calc.py
+++ b/examples/stream_calc/sc_tests/unit/test_calc.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/unit/test_eventpub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/sc_tests/unit/test_eventsub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventsub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/__init__.py
+++ b/examples/stream_calc/stream_calc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/__main__.py
+++ b/examples/stream_calc/stream_calc/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/config.py
+++ b/examples/stream_calc/stream_calc/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/core/__init__.py
+++ b/examples/stream_calc/stream_calc/core/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/core/calc.py
+++ b/examples/stream_calc/stream_calc/core/calc.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/inject.py
+++ b/examples/stream_calc/stream_calc/inject.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/main.py
+++ b/examples/stream_calc/stream_calc/main.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/ports/__init__.py
+++ b/examples/stream_calc/stream_calc/ports/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/ports/problem_receiver.py
+++ b/examples/stream_calc/stream_calc/ports/problem_receiver.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/ports/result_emitter.py
+++ b/examples/stream_calc/stream_calc/ports/result_emitter.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/translators/__init__.py
+++ b/examples/stream_calc/stream_calc/translators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/translators/eventpub.py
+++ b/examples/stream_calc/stream_calc/translators/eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/stream_calc/translators/eventsub.py
+++ b/examples/stream_calc/stream_calc/translators/eventsub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/stream_calc/submit_example_problems.py
+++ b/examples/stream_calc/submit_example_problems.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lock/README.md
+++ b/lock/README.md
@@ -1,5 +1,5 @@
 <!--
- Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+ Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
  for the German Human Genome-Phenome Archive (GHGA)
 
  Licensed under the Apache License, Version 2.0 (the "License");

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -3,7 +3,6 @@
 pytest>=8.1
 pytest-asyncio>=0.23
 pytest-cov>=5
-pytest-profiling>=1.7
 snakeviz>=2.2
 logot>=1.3
 

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -48,12 +48,12 @@ attrs==23.2.0 \
     # via
     #   jsonschema
     #   referencing
-boto3==1.34.84 \
-    --hash=sha256:7a02f44af32095946587d748ebeb39c3fa15b9d7275307ff612a6760ead47e04 \
-    --hash=sha256:91e6343474173e9b82f603076856e1d5b7b68f44247bdd556250857a3f16b37b
-botocore==1.34.84 \
-    --hash=sha256:a2b309bf5594f0eb6f63f355ade79ba575ce8bf672e52e91da1a7933caa245e6 \
-    --hash=sha256:da1ae0a912e69e10daee2a34dafd6c6c106450d20b8623665feceb2d96c173eb
+boto3==1.34.85 \
+    --hash=sha256:135f1358fbc7d7dc89ad1a4346cb8da621fdc2aea69deb7b20c71ffec7cde111 \
+    --hash=sha256:de73d0f2dec1819074caf3f0888e18f6e13a9fb75ef5f17b1bdd9d1acc127b33
+botocore==1.34.85 \
+    --hash=sha256:18548525d4975bbe982f393f6470ba45249919a93f5dc6a69e37e435dd2cf579 \
+    --hash=sha256:9abae3f7925a8cc2b91b6ff3f09e631476c74826d45dc44fb30d1d15960639db
     # via
     #   boto3
     #   s3transfer
@@ -954,9 +954,9 @@ uv==0.1.32 \
     --hash=sha256:ed6a41164aac4538a5bbb850ab52a6c2a679e9aa642f32f001799fd5a3ccf00c \
     --hash=sha256:f61de511a3296aa9519ac9cc1d30987aea00a94cd964c8227088a14f0b3f3ab3 \
     --hash=sha256:faf8bba1feb328b93376c2ff26a436a4a41ac45e12c3e46a850edb289e7653fd
-virtualenv==20.25.1 \
-    --hash=sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a \
-    --hash=sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197
+virtualenv==20.25.2 \
+    --hash=sha256:6e1281a57849c8a54da89ba82e5eb7c8937b9d057ff01aaf5bc9afaa3552e90f \
+    --hash=sha256:fa7edb8428620518010928242ec17aa7132ae435319c29c1651d1cf4c4173aad
     # via
     #   pre-commit
     #   tox

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -341,10 +341,6 @@ filelock==3.13.4 \
     # via
     #   tox
     #   virtualenv
-gprof2dot==2022.7.29 \
-    --hash=sha256:45b4d298bd36608fccf9511c3fd88a773f7a1abc04d6cd39445b11ba43133ec5 \
-    --hash=sha256:f165b3851d3c52ee4915eb1bd6cca571e5759823c2cd0f71a79bda93c2dc85d6
-    # via pytest-profiling
 h11==0.14.0 \
     --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
     --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
@@ -653,7 +649,6 @@ pytest==8.1.1 \
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-httpx
-    #   pytest-profiling
 pytest-asyncio==0.23.6 \
     --hash=sha256:68516fdd1018ac57b846c9846b954f0393b26f094764a28c955eabb0536a4e8a \
     --hash=sha256:ffe523a89c1c222598c76856e76852b787504ddb72dd5d9b6617ffa8aa2cde5f
@@ -663,9 +658,6 @@ pytest-cov==5.0.0 \
 pytest-httpx==0.30.0 \
     --hash=sha256:6d47849691faf11d2532565d0c8e0e02b9f4ee730da31687feae315581d7520c \
     --hash=sha256:755b8edca87c974dd4f3605c374fda11db84631de3d163b99c0df5807023a19a
-pytest-profiling==1.7.0 \
-    --hash=sha256:93938f147662225d2b8bd5af89587b979652426a8a6ffd7e73ec4a23e24b7f29 \
-    --hash=sha256:999cc9ac94f2e528e3f5d43465da277429984a1c237ae9818f8cfd0b06acb019
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
@@ -879,9 +871,7 @@ shellingham==1.5.4 \
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
-    # via
-    #   pytest-profiling
-    #   python-dateutil
+    # via python-dateutil
 snakeviz==2.2.0 \
     --hash=sha256:569e2d71c47f80a886aa6e70d6405cb6d30aa3520969ad956b06f824c5f02b8e \
     --hash=sha256:7bfd00be7ae147eb4a170a471578e1cd3f41f803238958b6b8efcf2c698a6aa9
@@ -946,24 +936,24 @@ urllib3==1.26.18 \
     #   docker
     #   requests
     #   testcontainers
-uv==0.1.31 \
-    --hash=sha256:41d4ea56d0fe016b028b4737100d5195c2e6be0004b995ae3a9563ca5ca1808c \
-    --hash=sha256:4defd32ada473e8f2a19325e7f0b9607fcc5be4d911b343ef75ab2f2bc9a0f2b \
-    --hash=sha256:686e792582df3afa560952f0542b582bba8a51b6bb93ff902ab836bba3b665df \
-    --hash=sha256:6d23049581707514e69960b25a0d58d27e759d4f2e014b276f7d29c2b2d8e9fe \
-    --hash=sha256:83647b7ae84cad7a0d851ca12c0c9bfc7523ab49d3407efe7a59d1d8709cbfb9 \
-    --hash=sha256:a4c43102a3d20f1a550dc33de0bbf70e388ad397403cf6cbe2a8fb996de59f9c \
-    --hash=sha256:b0ea20afb087b8952bd03ce2434064d2164328ae3dccfab0d2dab1bf2c13aed6 \
-    --hash=sha256:c2ba42a02fdd159d73c352026e6f669440606efc5b634143e9e696cac640c4d4 \
-    --hash=sha256:c58fbf4b346eae235d60eab04d148726d982b25caa1162a030b6080d17c05445 \
-    --hash=sha256:ca5251a1e6b83d87fc7a0beebc89001ae194c29cee5b9636295fde77974f6ba2 \
-    --hash=sha256:d8883b63c4316d6dfa5523c3a054be225d9b0083a923d9ec95eb7649e8b2977a \
-    --hash=sha256:da4bc4a9f1373a52462fe2395c794c8b971c8b54d25e83228a092c16b42eec1f \
-    --hash=sha256:db7c079f018ecc9f845a81c2f0d80ac759341ed0ea712d4acd4d9f1ccdb7b65a \
-    --hash=sha256:e398795810e0dac7cfe179f6ea9406d40f939cea9d7c3e5834be86aaf1dede7c \
-    --hash=sha256:eca2d8808b7972aeeb0aac6bd05e4bb4dcb6bdc709bc60addf5cac9c21cc7c07 \
-    --hash=sha256:f322dbfb1852499b8d9cf1932135d4a78f6605fd701eb77d0608da5116e993fa \
-    --hash=sha256:fa0058c437042654967cb53fcbef414c92504367a5519ecbc71fdb8d1300b843
+uv==0.1.32 \
+    --hash=sha256:0c9ca49cc73bf61eaf88d005bc16193a2f211a736f26c7612fa158a9a44c4efc \
+    --hash=sha256:0db70283655a2bee8129562b0d0c33979a9ea0586572402a226ffae370e24d20 \
+    --hash=sha256:11f1df69d5adad54871e12ed7d7c9250deda9da4800b3dadfa84a65625e945f5 \
+    --hash=sha256:2d1c85698040efe36b2ddf8b9072c8f01c14a9fa164b5d0a2e6b0dbb11443439 \
+    --hash=sha256:339a275711f2c1faab155f47c2e06e272292401ab054ede37d92ef7ebbffad9b \
+    --hash=sha256:47ff7ab9cdadf01033663b74d65a57648f41b81d07f047370b7eefff934680ec \
+    --hash=sha256:5af112155bbd9b0abe7748d6b31186c3c0c8cf7931dc99762cc45ad9f44732f7 \
+    --hash=sha256:907ff64b74da60e2280b4536f7ae64539219254286c81b857f709ab2e91487ff \
+    --hash=sha256:9365a51e1dd711b8cab661a481b1222dba721497b8a7604bb1fe8e63db900476 \
+    --hash=sha256:a7547b19596bec70a041d4c74af1cdd5c3f426c9dd0edb5b6c98a159cc65f43f \
+    --hash=sha256:ac453ebbc52da083501a56e0378a71be637920c4cbf60b6dca64292464a00c23 \
+    --hash=sha256:c3b9bb6194e3e2ea41174fc49d66d09eeb5566a5b3c6a6476f30ea2342e547f5 \
+    --hash=sha256:dac71a5abac7c45914acbdc5760be1c7c14c8ce4da7447dfa4f661a57d3d0afe \
+    --hash=sha256:e10e3a44c73934a78eaac199952585aed1f8b0c742b8b034570b3816cb9071af \
+    --hash=sha256:ed6a41164aac4538a5bbb850ab52a6c2a679e9aa642f32f001799fd5a3ccf00c \
+    --hash=sha256:f61de511a3296aa9519ac9cc1d30987aea00a94cd964c8227088a14f0b3f3ab3 \
+    --hash=sha256:faf8bba1feb328b93376c2ff26a436a4a41ac45e12c3e46a850edb289e7653fd
 virtualenv==20.25.1 \
     --hash=sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a \
     --hash=sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -44,12 +44,12 @@ attrs==23.2.0 \
     # via
     #   jsonschema
     #   referencing
-boto3==1.34.84 \
-    --hash=sha256:7a02f44af32095946587d748ebeb39c3fa15b9d7275307ff612a6760ead47e04 \
-    --hash=sha256:91e6343474173e9b82f603076856e1d5b7b68f44247bdd556250857a3f16b37b
-botocore==1.34.84 \
-    --hash=sha256:a2b309bf5594f0eb6f63f355ade79ba575ce8bf672e52e91da1a7933caa245e6 \
-    --hash=sha256:da1ae0a912e69e10daee2a34dafd6c6c106450d20b8623665feceb2d96c173eb
+boto3==1.34.85 \
+    --hash=sha256:135f1358fbc7d7dc89ad1a4346cb8da621fdc2aea69deb7b20c71ffec7cde111 \
+    --hash=sha256:de73d0f2dec1819074caf3f0888e18f6e13a9fb75ef5f17b1bdd9d1acc127b33
+botocore==1.34.85 \
+    --hash=sha256:18548525d4975bbe982f393f6470ba45249919a93f5dc6a69e37e435dd2cf579 \
+    --hash=sha256:9abae3f7925a8cc2b91b6ff3f09e631476c74826d45dc44fb30d1d15960639db
     # via
     #   boto3
     #   s3transfer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,4 +183,4 @@ source = [
 ]
 
 [tool.tox]
-legacy_tox_ini = "    [tox]\n    min_version = 4.0\n    env_list =\n        py39\n        py312\n\n    [testenv]\n    pass_env=\n        TC_HOST\n        DOCKER_HOST\n    deps =\n        --no-deps -r ./lock/requirements-dev.txt\n    commands = pytest ./tests {posargs}\n"
+legacy_tox_ini = "    [tox]\n    env_list = py3{9,12}\n\n    [gh-actions]\n    python =\n        3.9: py39\n        3.10: py310\n        3.11: py311\n        3.12: py312\n\n    [testenv]\n    pass_env =\n        TC_HOST\n        DOCKER_HOST\n    deps =\n        --no-deps -r ./lock/requirements-dev.txt\n    commands = pytest {posargs}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=67.7.2",
+    "setuptools>=69",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -172,7 +172,7 @@ check_untyped_defs = true
 no_site_packages = false
 
 [tool.pytest.ini_options]
-minversion = "7.1"
+minversion = "8.0"
 asyncio_mode = "strict"
 
 [tool.coverage.paths]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/get_package_name.py
+++ b/scripts/get_package_name.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/license_checker.py
+++ b/scripts/license_checker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -296,7 +296,7 @@ def validate_year_string(year_string: str, min_year: int = MIN_YEAR) -> bool:
     if year_string.isnumeric():
         return int(year_string) == current_year
 
-    # Otherwise, a range (e.g. 2021 - 2023) is expected:
+    # Otherwise, a range (e.g. 2021 - 2024) is expected:
     match = re.match(r"(\d+) - (\d+)", year_string)
 
     if not match:

--- a/scripts/list_outdated_dependencies.py
+++ b/scripts/list_outdated_dependencies.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/__init__.py
+++ b/scripts/script_utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/cli.py
+++ b/scripts/script_utils/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/deps.py
+++ b/scripts/script_utils/deps.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/script_utils/lock_deps.py
+++ b/scripts/script_utils/lock_deps.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_hook_revs.py
+++ b/scripts/update_hook_revs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_lock.py
+++ b/scripts/update_lock.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_pyproject.py
+++ b/scripts/update_pyproject.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/__init__.py
+++ b/src/hexkit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/__main__.py
+++ b/src/hexkit/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/base.py
+++ b/src/hexkit/base.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/config.py
+++ b/src/hexkit/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/correlation.py
+++ b/src/hexkit/correlation.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/custom_types.py
+++ b/src/hexkit/custom_types.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/__init__.py
+++ b/src/hexkit/protocols/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/daopub.py
+++ b/src/hexkit/protocols/daopub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/daosub.py
+++ b/src/hexkit/protocols/daosub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/eventpub.py
+++ b/src/hexkit/protocols/eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/eventsub.py
+++ b/src/hexkit/protocols/eventsub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/__init__.py
+++ b/src/hexkit/providers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/__init__.py
+++ b/src/hexkit/providers/akafka/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/provider/__init__.py
+++ b/src/hexkit/providers/akafka/provider/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/provider/utils.py
+++ b/src/hexkit/providers/akafka/provider/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/testcontainer.py
+++ b/src/hexkit/providers/akafka/testcontainer.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/akafka/testutils.py
+++ b/src/hexkit/providers/akafka/testutils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/mongodb/__init__.py
+++ b/src/hexkit/providers/mongodb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/mongodb/testutils.py
+++ b/src/hexkit/providers/mongodb/testutils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/mongokafka/__init__.py
+++ b/src/hexkit/providers/mongokafka/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/s3/__init__.py
+++ b/src/hexkit/providers/s3/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/s3/provider.py
+++ b/src/hexkit/providers/s3/provider.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/s3/test_files/__init__.py
+++ b/src/hexkit/providers/s3/test_files/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/s3/testutils.py
+++ b/src/hexkit/providers/s3/testutils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/testing/__init__.py
+++ b/src/hexkit/providers/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/providers/testing/eventpub.py
+++ b/src/hexkit/providers/testing/eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/hexkit/utils.py
+++ b/src/hexkit/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/config.py
+++ b/tests/fixtures/config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/kafka_secrets.py
+++ b/tests/fixtures/kafka_secrets.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/test_files/__init__.py
+++ b/tests/fixtures/test_files/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_dao.py
+++ b/tests/unit/test_dao.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_eventpub.py
+++ b/tests/unit/test_eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_eventsub.py
+++ b/tests/unit/test_eventsub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_testing_eventpub.py
+++ b/tests/unit/test_testing_eventpub.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
 # for the German Human Genome-Phenome Archive (GHGA)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR aligns the GitHub actions with the microservice template and the service commons library. This means that
- tox can now run properly on GitHub (this did not work before)
- all the license headers have been updated