### PR TITLE
Fix problem with sys.path in local test with tox

### DIFF
--- a/examples/stream_calc/sc_tests/integration/test_cli.py
+++ b/examples/stream_calc/sc_tests/integration/test_cli.py
@@ -18,6 +18,7 @@
 
 import asyncio
 import os
+import site
 import subprocess
 import sys
 from pathlib import Path
@@ -42,7 +43,7 @@ async def test_cli(kafka_fixture: KafkaFixture, monkeypatch):  # noqa:F811
         name="STREAM_CALC_KAFKA_SERVERS", value=f'["{kafka_fixture.kafka_servers[0]}"]'
     )
     monkeypatch.setenv(
-        name="PYTHONPATH", value=(os.environ.get("PYTHONPATH", "") + f":{APP_DIR}")
+        name="PYTHONPATH", value=":".join([str(APP_DIR), *site.getsitepackages()])
     )
 
     await submit_test_problems(CASES, kafka_server=kafka_fixture.kafka_servers[0])


### PR DESCRIPTION
The CLI test for the stream calc example failed with tox and Python 3.12 when run locally. The reason was that in the sub process created by the test, the sys.path was not set properly to the tox environment. Improved the test by handing over the site packages paths via PYTHONPATH, so that it works in this scenario as well.