### PR TITLE
Fix DAO publisher inconsistencies

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "3.0.1"
+version = "3.0.2"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "3.0.1"
+version = "3.0.2"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -132,7 +132,7 @@ class DaoCommons(typing.Protocol[Dto]):
         """
         ...
 
-    async def delete(self, *, id_: str) -> None:
+    async def delete(self, id_: str) -> None:
         """Delete a resource by providing its ID.
 
         Args:

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -201,7 +201,7 @@ class MongoDbDaoBase(ABC, Generic[Dto]):
         # (trusting MongoDB that matching on the _id field can only yield one or
         # zero matches)
 
-    async def delete(self, *, id_: str) -> None:
+    async def delete(self, id_: str) -> None:
         """Delete a resource by providing its ID.
 
         Args:

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -239,7 +239,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         if self._autopublish:
             await self._publish_change(dto)
 
-    async def delete(self, *, id_: str) -> None:
+    async def delete(self, id_: str) -> None:
         """Delete a resource by providing its ID.
 
         Args:

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -187,7 +187,7 @@ async def test_dao_happy(mongodb: MongoDbFixture):
     assert obtained_hit == resource_updated
 
     # delete the resource:
-    await dao.delete(id_=resource_inserted.id)
+    await dao.delete(resource_inserted.id)
 
     # confirm that the resource was deleted:
     with pytest.raises(ResourceNotFoundError):
@@ -273,7 +273,7 @@ async def test_dao_delete_not_found(mongodb: MongoDbFixture):
     )
 
     with pytest.raises(ResourceNotFoundError):
-        await dao.delete(id_="my_non_existing_id_001")
+        await dao.delete("my_non_existing_id_001")
 
 
 async def test_dao_find_invalid_mapping(mongodb: MongoDbFixture):

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -95,7 +95,7 @@ async def test_dao_outbox_with_non_existing_resource(
                 elif operation == "update":
                     await dao.update(example)
                 elif operation == "delete":
-                    await dao.delete(id_=example.id)
+                    await dao.delete(example.id)
                 else:
                     assert False, f"Invalid operation: {operation}"
 
@@ -211,7 +211,7 @@ async def test_dao_outbox_happy(
             ],
             in_topic=EXAMPLE_TOPIC,
         ):
-            await dao.delete(id_=example.id)
+            await dao.delete(example.id)
 
         # confirm that the resource was deleted:
         with pytest.raises(ResourceNotFoundError):
@@ -367,7 +367,7 @@ async def test_dao_pub_sub_happy(mongo_kafka_config: MongoKafkaConfig):
         await dao.update(example_update)
 
         # delete the resource again:
-        await dao.delete(id_=example.id)
+        await dao.delete(example.id)
 
     expected_events = [
         (example.id, example),


### PR DESCRIPTION
This PR fixes two inconsistencies in the `delete()` method of the DAO publisher:

1. It did not raise `ResourceNotFoundError` as documented and like the normal DAO
2. The `id` cannot be passed using a positional argument, like in `get_by_id()` and `update()`.

The PR also fixes the case when an already deleted resource is updated or deleted.