### PR TITLE
Correlation ID in Outbox (GSI-764)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "3.1.0"
+version = "3.2.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -29,4 +29,4 @@ setuptools>=69.5
 # required since switch to pyproject.toml and pip-tools
 tomli_w>=1.0
 
-uv>=0.1.39
+uv>=0.1.44

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "3.1.0"
+version = "3.2.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",


### PR DESCRIPTION
The correlation ID will be stored in the metadata of documents managed by outbox DAOs. When republishing occurs, the correlation ID will be 'restored' from the metadata. Doing this can aid in idempotency for consuming services when used with other methods such as hash sums on payloads. 

Bumps version from 3.1.0 -> 3.2.0

`fail-fast: false` was added to the test strategy as well.