### PR TITLE
Allow selective suppression of publication in DaoPublisher

### DIFF
--- a/src/hexkit/protocols/daopub.py
+++ b/src/hexkit/protocols/daopub.py
@@ -62,7 +62,7 @@ class DaoPublisherFactoryProtocol(DaoFactoryBase, ABC):
         dto_model: type[Dto],
         id_field: str,
         fields_to_index: Optional[Collection[str]] = None,
-        dto_to_event: Callable[[Dto], JsonObject],
+        dto_to_event: Callable[[Dto], Optional[JsonObject]],
         event_topic: str,
         autopublish: bool = True,
     ) -> DaoPublisher[Dto]:
@@ -82,6 +82,7 @@ class DaoPublisherFactoryProtocol(DaoFactoryBase, ABC):
                 `id_field`. Defaults to None.
             dto_to_event:
                 A function that takes a DTO and returns the payload for an event.
+                If the returned payload is None, the event will not be published.
             event_topic:
                 The topic to which events should be published.
             autopublish:
@@ -120,7 +121,7 @@ class DaoPublisherFactoryProtocol(DaoFactoryBase, ABC):
         dto_model: type[Dto],
         id_field: str,
         fields_to_index: Optional[Collection[str]],
-        dto_to_event: Callable[[Dto], JsonObject],
+        dto_to_event: Callable[[Dto], Optional[JsonObject]],
         event_topic: str,
         autopublish: bool,
     ) -> DaoPublisher[Dto]:

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -116,7 +116,7 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
     await kafka.clear_topics(topics="clear_topic")
 
     # make sure the keep_topic still has its event but clear_topic is empty
-    prefetched = await consumer.getmany(timeout_ms=1000)
+    prefetched = await consumer.getmany(timeout_ms=5000)
     assert len(prefetched) == 1
     records = next(iter(prefetched.values()))
     assert len(records) == 1
@@ -137,7 +137,7 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
     # make sure messages are consumed again
     records = []
     while True:
-        prefetched = await consumer.getmany(timeout_ms=1000)
+        prefetched = await consumer.getmany(timeout_ms=5000)
         if not prefetched:
             break
         assert len(prefetched) <= 2

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -116,7 +116,7 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
     await kafka.clear_topics(topics="clear_topic")
 
     # make sure the keep_topic still has its event but clear_topic is empty
-    prefetched = await consumer.getmany(timeout_ms=500)
+    prefetched = await consumer.getmany(timeout_ms=1000)
     assert len(prefetched) == 1
     records = next(iter(prefetched.values()))
     assert len(records) == 1
@@ -137,7 +137,7 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
     # make sure messages are consumed again
     records = []
     while True:
-        prefetched = await consumer.getmany(timeout_ms=500)
+        prefetched = await consumer.getmany(timeout_ms=1000)
         if not prefetched:
             break
         assert len(prefetched) <= 2

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -333,6 +333,12 @@ async def test_suppress_publishing(mongo_kafka: MongoKafkaFixture):
             for example in examples:
                 await dao.insert(example)
 
+        # check that all resources were saved:
+        records = [record async for record in dao.find_all(mapping={})]
+        assert len(records) == 3
+        assert any(record.field_c for record in records)
+
+        # check that the second resource was not published:
         assert len(recorder.recorded_events) == 2
         assert all(event.payload["field_c"] for event in recorder.recorded_events)
 

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -521,7 +521,7 @@ async def test_dao_pub_sub_invalid_dto(mongo_kafka: MongoKafkaFixture):
             await subscriber.run(forever=False)
 
 
-async def test_mongokafa_dao_correlation_id_upsert(mongo_kafka: MongoKafkaFixture):
+async def test_mongokafka_dao_correlation_id_upsert(mongo_kafka: MongoKafkaFixture):
     """Make sure the correlation ID is set on the document metadata in upsertion.
 
     Insert a new document and verify that the correct correlation ID is there.
@@ -579,7 +579,7 @@ async def test_mongokafa_dao_correlation_id_upsert(mongo_kafka: MongoKafkaFixtur
             )
 
 
-async def test_mongokafa_dao_correlation_id_delete(mongo_kafka: MongoKafkaFixture):
+async def test_mongokafka_dao_correlation_id_delete(mongo_kafka: MongoKafkaFixture):
     """Make sure the correlation ID is set on the document metadata in deletion."""
     async with MongoKafkaDaoPublisherFactory.construct(
         config=mongo_kafka.config


### PR DESCRIPTION
DaoPublisher: Allow `dto_to_event` to return None and in that case suppress the publication of the event.