### PR TITLE
Iron out flaky kafka test (GSI-793)

### DIFF
--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -136,9 +136,8 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
 
     # make sure messages are consumed again
     records = []
-    while (fetches := 0) < 10:
+    for _ in range(10):
         # use limit in case of changes that cause unintended infinite loop here
-        fetches += 1
         prefetched = await consumer.getmany(timeout_ms=500)
         if prefetched:
             records.extend(next(iter(prefetched.values())))

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -136,7 +136,9 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
 
     # make sure messages are consumed again
     records = []
-    while True:
+    while (fetches := 0) < 10:
+        # use limit in case of changes that cause unintended infinite loop here
+        fetches += 1
         prefetched = await consumer.getmany(timeout_ms=500)
         if prefetched:
             records.extend(next(iter(prefetched.values())))

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -18,7 +18,6 @@
 
 import json
 from collections.abc import Sequence
-from contextlib import suppress
 
 import pytest
 from aiokafka import AIOKafkaConsumer
@@ -140,8 +139,7 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
     while True:
         prefetched = await consumer.getmany(timeout_ms=500)
         if prefetched:
-            with suppress(StopIteration):
-                records.extend(next(iter(prefetched.values())))
+            records.extend(next(iter(prefetched.values())))
         if len(records) >= 2:
             break
 

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -136,14 +136,9 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
 
     # make sure messages are consumed again
     records = []
-    for _ in range(10):
-        # use limit in case of changes that cause unintended infinite loop here
-        prefetched = await consumer.getmany(timeout_ms=500)
-        if prefetched:
-            for records_for_topic in prefetched.values():
-                records.extend(records_for_topic)
-        if len(records) >= 2:
-            break
+    while prefetched := await consumer.getmany(timeout_ms=500):
+        for records_for_topic in prefetched.values():
+            records.extend(records_for_topic)
 
     assert len(records) == 2
     records.sort(key=lambda record: record.topic)

--- a/tests/integration/test_akafka_testutils.py
+++ b/tests/integration/test_akafka_testutils.py
@@ -140,7 +140,8 @@ async def test_clear_topics_specific(kafka: KafkaFixture):
         # use limit in case of changes that cause unintended infinite loop here
         prefetched = await consumer.getmany(timeout_ms=500)
         if prefetched:
-            records.extend(next(iter(prefetched.values())))
+            for records_for_topic in prefetched.values():
+                records.extend(records_for_topic)
         if len(records) >= 2:
             break
 


### PR DESCRIPTION
The `.getmany()` call seems to often pull one record at a time in this test, at least when run locally. During the time the tests were failing, there was a `break` statement that would get hit after retrieving any records, regardless of count.