### PR TITLE
Replace yaml_settings_factory with pydantic equivalent (GSI-897)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "3.4.0"
+version = "3.4.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "3.4.0"
+version = "3.4.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",


### PR DESCRIPTION
Bump version from 3.4.0 -> 3.4.1  
I tried to devise a simpler version of `config_from_yaml` to reduce or eliminate the nesting without changing the usage, but was unable to do so, so the only change is eliminating the `yaml_settings_factory` function and replacing it with pydantic's `YamlConfigSettingsSource`