### PR TITLE
Kafka DLQ 

### DIFF
--- a/.template/mandatory_files.txt
+++ b/.template/mandatory_files.txt
@@ -23,6 +23,7 @@ lock/requirements-dev.txt
 lock/requirements.txt
 
 Dockerfile
+Dockerfile.debian
 config_schema.json
 example_config.yaml
 LICENSE

--- a/.template/mandatory_files_ignore.txt
+++ b/.template/mandatory_files_ignore.txt
@@ -10,6 +10,7 @@
 scripts/script_utils/fastapi_app_location.py
 
 Dockerfile
+Dockerfile.debian
 config_schema.json
 example_config.yaml
 

--- a/src/hexkit/config.py
+++ b/src/hexkit/config.py
@@ -143,7 +143,7 @@ def config_from_yaml(
                 model_config = SettingsConfigDict(frozen=True, env_prefix=f"{prefix}_")
 
                 @classmethod
-                def settings_customise_sources(  # noqa: PLR0913
+                def settings_customise_sources(
                     cls,
                     settings_cls: type[BaseSettings],
                     init_settings: PydanticBaseSettingsSource,

--- a/src/hexkit/custom_types.py
+++ b/src/hexkit/custom_types.py
@@ -27,12 +27,12 @@ JsonObject = Mapping[
 
 
 # A type indicating that a string should be ascii-compatible.
-# Technically it is an alias for `str` so it only serves documention purposes.
+# Technically it is an alias for `str` so it only serves documentation purposes.
 Ascii = str
 
 
 # A AsyncConstructable is a class with a async (class-)method `construct` that is used when
-# asynchronous constuction/instantiation logic is needed (which cannot be handeled in
+# asynchronous construction/instantiation logic is needed (which cannot be handled in
 # a synchronous __init__ method).
 # With the current typing features of Python, it seems not possible to correctly type
 # a class with that signature.

--- a/src/hexkit/protocols/eventpub.py
+++ b/src/hexkit/protocols/eventpub.py
@@ -54,7 +54,7 @@ class EventPublisherProtocol(ABC):
             type_=type_,
             key=key,
             topic=topic,
-            headers=headers if headers is not None else {},
+            headers=headers,
         )
 
     @abstractmethod

--- a/src/hexkit/protocols/eventpub.py
+++ b/src/hexkit/protocols/eventpub.py
@@ -17,6 +17,8 @@
 """Protocol related to event publishing."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from typing import Optional
 
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.utils import check_ascii
@@ -25,32 +27,53 @@ from hexkit.utils import check_ascii
 class EventPublisherProtocol(ABC):
     """A protocol for publishing events to an event broker."""
 
-    async def publish(
-        self, *, payload: JsonObject, type_: Ascii, key: Ascii, topic: Ascii
+    async def publish(  # noqa: PLR0913
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        key: Ascii,
+        topic: Ascii,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """Publish an event.
 
         Args:
-            payload (JSON): The payload to ship with the event.
-            type_ (str): The event type. ASCII characters only.
-            key (str): The event type. ASCII characters only.
-            topic (str): The event type. ASCII characters only.
+        - `payload` (JSON): The payload to ship with the event.
+        - `type_` (str): The event type. ASCII characters only.
+        - `key` (str): The event type. ASCII characters only.
+        - `topic` (str): The event type. ASCII characters only.
+        - `headers`: Additional headers to attach to the event.
         """
         check_ascii(type_, key, topic)
+        if headers is None:
+            headers = {}
+
         await self._publish_validated(
-            payload=payload, type_=type_, key=key, topic=topic
+            payload=payload,
+            type_=type_,
+            key=key,
+            topic=topic,
+            headers=headers if headers is not None else {},
         )
 
     @abstractmethod
-    async def _publish_validated(
-        self, *, payload: JsonObject, type_: Ascii, key: Ascii, topic: Ascii
+    async def _publish_validated(  # noqa: PLR0913
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        key: Ascii,
+        topic: Ascii,
+        headers: Mapping[str, str],
     ) -> None:
         """Publish an event with already validated topic and type.
 
         Args:
-            payload (JSON): The payload to ship with the event.
-            type_ (str): The event type. ASCII characters only.
-            key (str): The event type. ASCII characters only.
-            topic (str): The event type. ASCII characters only.
+        - `payload` (JSON): The payload to ship with the event.
+        - `type_` (str): The event type. ASCII characters only.
+        - `key` (str): The event type. ASCII characters only.
+        - `topic` (str): The event type. ASCII characters only.
+        - `headers`: Additional headers to attach to the event.
         """
         ...

--- a/src/hexkit/protocols/eventpub.py
+++ b/src/hexkit/protocols/eventpub.py
@@ -27,7 +27,7 @@ from hexkit.utils import check_ascii
 class EventPublisherProtocol(ABC):
     """A protocol for publishing events to an event broker."""
 
-    async def publish(  # noqa: PLR0913
+    async def publish(
         self,
         *,
         payload: JsonObject,
@@ -58,7 +58,7 @@ class EventPublisherProtocol(ABC):
         )
 
     @abstractmethod
-    async def _publish_validated(  # noqa: PLR0913
+    async def _publish_validated(
         self,
         *,
         payload: JsonObject,

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -117,6 +117,15 @@ class KafkaConfig(BaseSettings):
         title="Kafka Enable DLQ",
         examples=[True, False],
     )
+    kafka_retry_backoff: NonNegativeInt = Field(
+        default=0,
+        description=(
+            "The number of seconds to wait before retrying a failed event. The backoff"
+            + " time is doubled for each retry attempt."
+        ),
+        title="Kafka Retry Backoff",
+        examples=[0, 1, 2, 3, 5],
+    )
 
     @model_validator(mode="after")
     def validate_retry_topic(self):

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -86,12 +86,14 @@ class KafkaConfig(BaseSettings):
         default="",
         description="The name of the service-specific topic used for the dead letter queue.",
         examples=["dcs-dlq", "ifrs-dlq", "mass-dlq"],
+        title="Kafka DLQ Topic",
     )
     kafka_retry_topic: str = Field(
         default="",
         description=(
             "The name of the service-specific topic used to retry previously failed events."
         ),
+        title="Kafka Retry Topic",
         examples=["dcs-dlq-retry", "ifrs-dlq-retry", "mass-dlq-retry"],
     )
     kafka_max_retries: NonNegativeInt = Field(
@@ -100,6 +102,7 @@ class KafkaConfig(BaseSettings):
             "The maximum number of times to immediately retry consuming an event upon"
             + " failure. Works independently of the dead letter queue."
         ),
+        title="Kafka Max Retries",
         examples=[0, 1, 2, 3, 5],
     )
     kafka_enable_dlq: bool = Field(
@@ -111,6 +114,7 @@ class KafkaConfig(BaseSettings):
             + " exhausting all retries, and both `kafka_dlq_topic` and"
             + " `kafka_retry_topic` must be set."
         ),
+        title="Kafka Enable DLQ",
         examples=[True, False],
     )
 

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -16,7 +16,7 @@
 
 """Apache Kafka specific configuration."""
 
-from typing import Literal, Self
+from typing import Literal
 
 from pydantic import Field, NonNegativeInt, PositiveInt, SecretStr, model_validator
 from pydantic_settings import BaseSettings
@@ -115,7 +115,7 @@ class KafkaConfig(BaseSettings):
     )
 
     @model_validator(mode="after")
-    def validate_retry_topic(self) -> Self:
+    def validate_retry_topic(self):
         """Ensure that the retry topic is not the same as the DLQ topic."""
         if self.kafka_retry_topic and self.kafka_retry_topic == self.kafka_dlq_topic:
             raise ValueError(

--- a/src/hexkit/providers/akafka/provider/__init__.py
+++ b/src/hexkit/providers/akafka/provider/__init__.py
@@ -24,7 +24,6 @@ from .eventpub import KafkaEventPublisher
 from .eventsub import (
     ConsumerEvent,
     KafkaEventSubscriber,
-    get_header_value,
     headers_as_dict,
 )
 
@@ -32,7 +31,6 @@ __all__ = [
     "KafkaEventPublisher",
     "KafkaEventSubscriber",
     "ConsumerEvent",
-    "get_header_value",
     "headers_as_dict",
     "KafkaOutboxSubscriber",
 ]

--- a/src/hexkit/providers/akafka/provider/__init__.py
+++ b/src/hexkit/providers/akafka/provider/__init__.py
@@ -23,14 +23,22 @@ from .daosub import KafkaOutboxSubscriber
 from .eventpub import KafkaEventPublisher
 from .eventsub import (
     ConsumerEvent,
+    ExtractedEventInfo,
+    KafkaDLQSubscriber,
     KafkaEventSubscriber,
     headers_as_dict,
+    process_dlq_event,
+    validate_dlq_headers,
 )
 
 __all__ = [
     "KafkaEventPublisher",
+    "ExtractedEventInfo",
     "KafkaEventSubscriber",
     "ConsumerEvent",
     "headers_as_dict",
     "KafkaOutboxSubscriber",
+    "KafkaDLQSubscriber",
+    "process_dlq_event",
+    "validate_dlq_headers",
 ]

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -21,6 +21,7 @@
 import logging
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
+from typing import Optional
 
 from aiokafka import AIOKafkaConsumer
 from pydantic import ValidationError
@@ -31,6 +32,7 @@ from hexkit.protocols.daosub import (
     DaoSubscriberProtocol,
     DtoValidationError,
 )
+from hexkit.protocols.eventpub import EventPublisherProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 from hexkit.providers.akafka.config import KafkaConfig
 from hexkit.providers.akafka.provider.eventsub import (
@@ -85,8 +87,8 @@ class TranslatorConverter(EventSubscriberProtocol):
                 dto = translator.dto_model.model_validate(payload)
             except ValidationError as error:
                 message = (
-                    f"The event of type {type_} on topic {topic} was not valid wrt. the"
-                    + " DTO model."
+                    f"The event of type {type_} on topic {topic}"
+                    + " was not valid wrt. the DTO model."
                 )
                 logging.error(message)
                 raise DtoValidationError(message) from error
@@ -110,21 +112,34 @@ class KafkaOutboxSubscriber(InboundProviderBase):
         *,
         config: KafkaConfig,
         translators: Sequence[DaoSubscriberProtocol],
+        publisher: Optional[EventPublisherProtocol] = None,
         kafka_consumer_cls: type[KafkaConsumerCompatible] = AIOKafkaConsumer,
     ):
         """Setup and teardown an instance of the provider.
 
         Args:
-            config: MongoDB-specific config parameters.
+        - `config`: MongoDB-specific config parameters.
+        - `translators`: A sequence of translators implementing the
+            `DaoSubscriberProtocol`.
+        - `publisher`: An instance of the publisher to use for the DLQ. Can be None if
+            not using the dead letter queue.
+        - `kafka_consumer_cls`: The Kafka consumer class to use. Defaults to
+            `AIOKafkaConsumer`.
 
         Returns:
             An instance of the provider.
         """
         translator_converter = TranslatorConverter(translators=translators)
 
+        if config.kafka_enable_dlq and publisher is None:
+            error = ValueError("A publisher is required when the DLQ is enabled.")
+            logging.error(error)
+            raise error
+
         async with KafkaEventSubscriber.construct(
             config=config,
             translator=translator_converter,
+            publisher=publisher,
             kafka_consumer_cls=kafka_consumer_cls,
         ) as event_subscriber:
             yield cls(event_subscriber=event_subscriber)

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -150,7 +150,7 @@ class KafkaEventPublisher(EventPublisherProtocol):
         self._producer = producer
         self._generate_correlation_id = generate_correlation_id
 
-    async def _publish_validated(  # noqa: PLR0913
+    async def _publish_validated(
         self,
         *,
         payload: JsonObject,

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -42,6 +42,8 @@ from hexkit.providers.akafka.provider.utils import (
     generate_ssl_context,
 )
 
+RESERVED_HEADERS = ["type", "correlation_id"]
+
 
 class KafkaProducerCompatible(Protocol):
     """A python duck type protocol describing an AIOKafkaProducer or equivalent."""
@@ -182,9 +184,8 @@ class KafkaEventPublisher(EventPublisherProtocol):
         # Create a shallow copy of the headers
         headers_copy = dict(headers)
 
-        # Check and log warnings for forbidden headers
-        forbidden_headers = ["type", "correlation_id"]
-        for header in forbidden_headers:
+        # Check and log warnings for reserved headers
+        for header in RESERVED_HEADERS:
             log_msg = (
                 f"The '{header}' header shouldn't be supplied, but was. Overwriting."
             )

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -166,8 +166,8 @@ class KafkaEventPublisher(EventPublisherProtocol):
         Args:
         - `payload` (JSON): The payload to ship with the event.
         - `type_` (str): The event type. ASCII characters only.
-        - `key` (str): The event type. ASCII characters only.
-        - `topic` (str): The event type. ASCII characters only.
+        - `key` (str): The event key. ASCII characters only.
+        - `topic` (str): The event topic. ASCII characters only.
         - `headers`: Additional headers to attach to the event.
         """
         try:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -389,9 +389,9 @@ class KafkaEventSubscriber(InboundProviderBase):
         correlation_id = event.headers.get("correlation_id", "")
         errors = []
         if not event.type_:
-            errors.append("type_ is empty")
+            errors.append("event type is empty")
         elif event.type_ not in self._types_whitelist:
-            errors.append(f"type_ '{event.type_}' is not in the whitelist")
+            errors.append(f"event type '{event.type_}' is not in the whitelist")
         if not correlation_id:
             errors.append("correlation_id is empty")
         if event.topic in (self._retry_topic, self._dlq_topic):

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -227,8 +227,8 @@ class KafkaEventSubscriber(InboundProviderBase):
             max_partition_fetch_bytes=config.kafka_max_message_size,
         )
 
+        await consumer.start()
         try:
-            await consumer.start()
             yield cls(
                 consumer=consumer,
                 translator=translator,
@@ -570,8 +570,8 @@ class KafkaDLQSubscriber(InboundProviderBase):
             max_partition_fetch_bytes=config.kafka_max_message_size,
         )
 
+        await consumer.start()
         try:
-            await consumer.start()
             yield cls(
                 dlq_topic=config.kafka_dlq_topic,
                 retry_topic=config.kafka_retry_topic,

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -192,7 +192,7 @@ class KafkaEventSubscriber(InboundProviderBase):
                 type annotation) and an application-specific port
                 (according to the triple hexagonal architecture).
             dlq_publisher:
-                running instance of publishing provider that implements the
+                A running instance of a publishing provider that implements the
                 EventPublisherProtocol, such as KafkaEventPublisher. Can be None if
                 not using the dead letter queue. It is used to publish events to the DLQ.
             kafka_consumer_cls:
@@ -255,7 +255,7 @@ class KafkaEventSubscriber(InboundProviderBase):
                 type annotation) and an application-specific port
                 (according to the triple hexagonal architecture).
             dlq_publisher:
-                running instance of publishing provider that implements the
+                A running instance of a publishing provider that implements the
                 EventPublisherProtocol, such as KafkaEventPublisher. Can be None if
                 not using the dead letter queue. It is used to publish events to the DLQ.
             config:
@@ -537,11 +537,11 @@ class KafkaDLQSubscriber(InboundProviderBase):
         - `config`:
             Config parameters needed for connecting to Apache Kafka.
         - `dlq_publisher`:
-            running instance of publishing provider that implements the
+            A running instance of a publishing provider that implements the
             EventPublisherProtocol, such as KafkaEventPublisher. It is used to publish
             events to the configured retry topic.
         - `kafka_consumer_cls`:
-            Overwrite the used Kafka consumer class . Only intended for unit testing.
+            Overwrite the used Kafka consumer class. Only intended for unit testing.
         - `process_dlq_event`:
             An async callable adhering to the DLQEventProcessor definition that provides
             validation and processing for events from the DLQ. It should return _either_
@@ -597,7 +597,7 @@ class KafkaDLQSubscriber(InboundProviderBase):
         - `consumer`:
             hands over a started AIOKafkaConsumer.
         - `dlq_publisher`:
-            running instance of publishing provider that implements the
+            A running instance of a publishing provider that implements the
             EventPublisherProtocol, such as KafkaEventPublisher.
         - `dlq_topic`:
             The name of the topic used to store failed events, to which the

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -494,7 +494,7 @@ def validate_dlq_headers(event: ConsumerEvent) -> None:
     """
     headers = headers_as_dict(event)
     expected_headers = ["type", "correlation_id", ORIGINAL_TOPIC_FIELD]
-    invalid_headers = [key for key in expected_headers if not headers.get(key, None)]
+    invalid_headers = [key for key in expected_headers if not headers.get(key)]
     if invalid_headers:
         error_msg = f"Missing or empty headers: {', '.join(invalid_headers)}"
         raise DLQValidationError(event=event, error=error_msg)

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -25,6 +25,7 @@ import json
 import logging
 import ssl
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Callable, Literal, Optional, Protocol, TypeVar
 
 from aiokafka import AIOKafkaConsumer
@@ -32,12 +33,15 @@ from aiokafka import AIOKafkaConsumer
 from hexkit.base import InboundProviderBase
 from hexkit.correlation import set_correlation_id
 from hexkit.custom_types import Ascii, JsonObject
+from hexkit.protocols.eventpub import EventPublisherProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 from hexkit.providers.akafka.config import KafkaConfig
 from hexkit.providers.akafka.provider.utils import (
     generate_client_id,
     generate_ssl_context,
 )
+
+ORIGINAL_TOPIC_FIELD = "_original_topic"
 
 
 class EventHeaderNotFoundError(RuntimeError):
@@ -57,6 +61,24 @@ class ConsumerEvent(Protocol):
     headers: list[tuple[str, bytes]]
     partition: int
     offset: int
+
+
+@dataclass
+class ExtractedEvent:
+    """A class encapsulating the data extracted from a `ConsumerEvent` instance."""
+
+    topic: Ascii
+    type_: Ascii
+    payload: JsonObject
+    key: Ascii
+
+
+def get_event_label(event: ConsumerEvent) -> str:
+    """Make a label that identifies an event."""
+    return (
+        f"{event.topic} - {event.partition} - {event.key} - {event.offset}"
+        + " (topic-partition-key-offset)"
+    )
 
 
 def headers_as_dict(event: ConsumerEvent) -> dict[str, str]:
@@ -135,8 +157,23 @@ class KafkaConsumerCompatible(Protocol):
         ...
 
 
+class OriginalTopicError(RuntimeError):
+    """Raised when the original topic is missing from the event."""
+
+    def __init__(self, *, event_label: str):
+        super().__init__(f"Unable to get original topic from event: {event_label}.")
+
+
 class KafkaEventSubscriber(InboundProviderBase):
     """Apache Kafka-specific event subscription provider."""
+
+    class RetriesExhaustedError(RuntimeError):
+        """Raised when an event has been retried the maximum number of times."""
+
+        def __init__(self, *, event_type: str):
+            message = f"The maximum number of retries has been reached for '{
+                event_type}' event."
+            super().__init__(message)
 
     @classmethod
     @asynccontextmanager
@@ -146,9 +183,10 @@ class KafkaEventSubscriber(InboundProviderBase):
         config: KafkaConfig,
         translator: EventSubscriberProtocol,
         kafka_consumer_cls: type[KafkaConsumerCompatible] = AIOKafkaConsumer,
+        publisher: Optional[EventPublisherProtocol] = None,
     ):
         """
-        Setup and teardown KafkaEventPublisher instance with some config params.
+        Setup and teardown KafkaRetrySubscriber instance with some config params.
 
         Args:
             config:
@@ -157,6 +195,10 @@ class KafkaEventSubscriber(InboundProviderBase):
                 The translator that translates between the protocol (mentioned in the
                 type annotation) and an application-specific port
                 (according to the triple hexagonal architecture).
+            publisher:
+                running instance of publishing provider that implements the
+                EventPublisherProtocol, such as KafkaEventPublisher. Can be None if
+                not using the dead letter queue.
             kafka_consumer_cls:
                 Overwrite the used Kafka consumer class. Only intended for unit testing.
         """
@@ -165,6 +207,13 @@ class KafkaEventSubscriber(InboundProviderBase):
         )
 
         topics = translator.topics_of_interest
+
+        if config.kafka_enable_dlq:
+            if publisher is None:
+                error = ValueError("A publisher is required when the DLQ is enabled.")
+                logging.error(error)
+                raise error
+            topics.append(config.kafka_retry_topic)
 
         consumer = kafka_consumer_cls(
             *topics,
@@ -181,39 +230,146 @@ class KafkaEventSubscriber(InboundProviderBase):
             ),
             max_partition_fetch_bytes=config.kafka_max_message_size,
         )
+
         try:
             await consumer.start()
-            yield cls(consumer=consumer, translator=translator)
+            yield cls(
+                consumer=consumer,
+                translator=translator,
+                publisher=publisher,
+                config=config,
+            )
         finally:
             await consumer.stop()
 
     def __init__(
-        self, *, consumer: KafkaConsumerCompatible, translator: EventSubscriberProtocol
+        self,
+        *,
+        consumer: KafkaConsumerCompatible,
+        translator: EventSubscriberProtocol,
+        config: KafkaConfig,
+        publisher: Optional[EventPublisherProtocol] = None,
     ):
         """Please do not call directly! Should be called by the `construct` method.
         Args:
             consumer:
-                hands over a started AIOKafkaProducer.
+                hands over a started AIOKafkaConsumer.
             translator (EventSubscriberProtocol):
                 The translator that translates between the protocol (mentioned in the
                 type annotation) and an application-specific port
                 (according to the triple hexagonal architecture).
+            publisher:
+                running instance of publishing provider that implements the
+                EventPublisherProtocol, such as KafkaEventPublisher. Can be None if
+                not using the dead letter queue.
+            config:
+                the KafkaRetryConfig instance containing dlq topics and retry allowance.
         """
         self._consumer = consumer
         self._translator = translator
         self._types_whitelist = translator.types_of_interest
+        self._publisher = publisher
+        self._dlq_topic = config.kafka_dlq_topic
+        self._dlq_retry_topic = config.kafka_retry_topic
+        self._max_retries = config.kafka_max_retries
+        self._enable_dlq = config.kafka_enable_dlq
 
-    @staticmethod
-    def _get_event_label(event: ConsumerEvent) -> str:
-        """Get a label that identifies an event."""
-        return (
-            f"{event.topic} - {event.partition} - {event.key} - {event.offset}"
-            + " (topic-partition-offset)"
+    def _get_original_topic(self, event: ConsumerEvent) -> str:
+        """Get the topic to use -- either the given topic or the one from `_original_topic`.
+
+        Raises `OriginalTopicError` if the original topic name is missing for events in
+        the retry topic.
+        """
+        topic = event.topic
+        if topic == self._dlq_retry_topic:
+            topic = str(event.value.get(ORIGINAL_TOPIC_FIELD, ""))
+            if not topic:
+                event_label = get_event_label(event)
+                error = OriginalTopicError(event_label=event_label)
+                logging.error(error)
+                raise error
+            logging.info(
+                "Received previously failed event from topic '%s' for retry.", topic
+            )
+        return topic
+
+    async def _publish_to_dlq(self, *, event: ExtractedEvent):
+        """Publish the event to the DLQ topic."""
+        dlq_payload = {**event.payload, ORIGINAL_TOPIC_FIELD: event.topic}
+        logging.debug("Publishing failed event to DLQ topic '%s'.", self._dlq_topic)
+        await self._publisher.publish(  # type: ignore
+            payload=dlq_payload,
+            type_=event.type_,
+            topic=self._dlq_topic,
+            key=event.key,
         )
+        logging.info("Published event to DLQ topic '%s'", self._dlq_topic)
+
+    async def _retry_event(self, *, event: ExtractedEvent, retries_left: int):
+        """Retry the event until the maximum number of retries is reached."""
+        retries_left -= 1
+        try:
+            logging.info(
+                "Retrying event of type '%s' on topic '%s' with key '%s'.",
+                extra={
+                    "type": event.type_,
+                    "topic": event.topic,
+                    "key": event.key,
+                    "retries_left": retries_left,
+                },
+            )
+            await self._translator.consume(
+                payload=event.payload,
+                type_=event.type_,
+                topic=event.topic,
+                key=event.key,
+            )
+        except Exception as err:
+            if retries_left > 0:
+                await self._retry_event(event=event, retries_left=retries_left)
+            else:
+                raise self.RetriesExhaustedError(event_type=event.type_) from err
+
+    async def _handle_consumption(self, *, event: ExtractedEvent):
+        """Try to pass the event to the consumer.
+
+        If the event fails:
+        1. Retry until retries are exhausted, if retries are configured.
+        2. Publish the event to the DLQ topic if the DLQ is enabled. Done afterward.
+           or
+        3. Allow failure with unhandled error if DLQ is not configured.
+        """
+        try:
+            await self._translator.consume(
+                payload=event.payload,
+                type_=event.type_,
+                topic=event.topic,
+                key=event.key,
+            )
+        except Exception:
+            logging.warning(
+                "Failed initial attempt to consume event of type '%s' on topic '%s' with key '%s'.",
+                event.type_,
+                event.topic,
+                event.key,
+            )
+            if self._max_retries > 0:
+                # Don't raise RetriesExhaustedError unless retries are actually attempted
+                try:
+                    await self._retry_event(event=event, retries_left=self._max_retries)
+                except self.RetriesExhaustedError:
+                    if self._enable_dlq:
+                        await self._publish_to_dlq(event=event)
+                    else:
+                        raise
+            elif self._enable_dlq:
+                await self._publish_to_dlq(event=event)
+            else:
+                raise  # re-raise Exception
 
     async def _consume_event(self, event: ConsumerEvent) -> None:
         """Consume an event by passing it down to the translator via the protocol."""
-        event_label = self._get_event_label(event)
+        event_label = get_event_label(event)
         headers = headers_as_dict(event)
 
         try:
@@ -222,35 +378,43 @@ class KafkaEventSubscriber(InboundProviderBase):
                 header_name="correlation_id", headers=headers
             )
         except EventHeaderNotFoundError as err:
-            logging.warning("Ignored an event: %s. %s", event_label, err.args[0])
+            logging.warning("Ignored an event: %s.  %s", event_label, err.args[0])
             # acknowledge event receipt
             await self._consumer.commit()
             return
 
+        # If the event is from the DLQ retry topic, consume with the original topic
+        topic = self._get_original_topic(event=event)
+        payload = event.value
+        if topic != event.topic:
+            payload = {
+                k: v for k, v in event.value.items() if k != ORIGINAL_TOPIC_FIELD
+            }
+
         if type_ in self._types_whitelist:
             logging.info('Consuming event of type "%s": %s', type_, event_label)
-
+            extracted_event = ExtractedEvent(
+                type_=type_, topic=topic, payload=payload, key=event.key
+            )
             try:
                 async with set_correlation_id(correlation_id):
-                    # blocks until event processing is completed:
-                    await self._translator.consume(
-                        payload=event.value,
-                        type_=type_,
-                        topic=event.topic,
-                        key=event.key,
-                    )
-                    # acknowledge successfully processed event
-                    await self._consumer.commit()
+                    await self._handle_consumption(event=extracted_event)
             except Exception:
-                logging.error(
-                    "A fatal error occurred while processing the event: %s",
+                logging.critical(
+                    "An error occurred while processing the event: %s. It was NOT"
+                    " placed in the DLQ topic ('%s')",
                     event_label,
+                    self._dlq_topic,
                 )
                 raise
+            else:
+                # Only save consumed event offsets if it was successful or sent to DLQ
+                await self._consumer.commit()
 
         else:
             logging.info("Ignored event of type %s: %s", type_, event_label)
-            # acknowledge event receipt
+
+            # Always acknowledge event receipt for ignored events
             await self._consumer.commit()
 
     async def run(self, forever: bool = True) -> None:
@@ -266,3 +430,127 @@ class KafkaEventSubscriber(InboundProviderBase):
         else:
             event = await self._consumer.__anext__()
             await self._consume_event(event)
+
+
+class KafkaDLQSubscriber(InboundProviderBase):
+    """A kafka event subscriber that subscribes to the configured DLQ topic and either
+    discards each event or publishes it to the retry topic as instructed.
+    """
+
+    @classmethod
+    @asynccontextmanager
+    async def construct(
+        cls,
+        *,
+        config: KafkaConfig,
+        kafka_consumer_cls: type[KafkaConsumerCompatible] = AIOKafkaConsumer,
+        publisher: EventPublisherProtocol,
+    ):
+        """
+        Setup and teardown KafkaEventPublisher instance with some config params.
+
+        Args:
+            config:
+                Config parameters needed for connecting to Apache Kafka.
+            publisher:
+                running instance of publishing provider that implements the
+                EventPublisherProtocol, such as KafkaEventPublisher.
+            kafka_consumer_cls:
+                Overwrite the used Kafka consumer class . Only intended for unit testing.
+        """
+        client_id = generate_client_id(
+            service_name=config.service_name, instance_id=config.service_instance_id
+        )
+
+        consumer = kafka_consumer_cls(
+            config.kafka_dlq_topic,
+            bootstrap_servers=",".join(config.kafka_servers),
+            security_protocol=config.kafka_security_protocol,
+            ssl_context=generate_ssl_context(config),
+            client_id=client_id,
+            group_id=config.service_name,
+            auto_offset_reset="earliest",
+            enable_auto_commit=False,
+            key_deserializer=lambda event_key: event_key.decode("ascii"),
+            value_deserializer=lambda event_value: json.loads(
+                event_value.decode("ascii")
+            ),
+        )
+
+        try:
+            await consumer.start()
+            yield cls(
+                consumer=consumer,
+                publisher=publisher,
+                dlq_retry_topic=config.kafka_retry_topic,
+            )
+        finally:
+            await consumer.stop()
+
+    def __init__(
+        self,
+        *,
+        consumer: KafkaConsumerCompatible,
+        publisher: EventPublisherProtocol,
+        dlq_retry_topic: str,
+    ):
+        """Please do not call directly! Should be called by the `construct` method.
+        Args:
+            consumer:
+                hands over a started AIOKafkaConsumer.
+            publisher:
+                running instance of publishing provider that implements the
+                EventPublisherProtocol, such as KafkaEventPublisher.
+            dlq_retry_topic:
+                The name of the topic used to requeue failed events.
+        """
+        self._consumer = consumer
+        self._publisher = publisher
+        self._dlq_retry_topic = dlq_retry_topic
+
+    async def _publish_to_retry(self, event: ConsumerEvent):
+        """Publish the event to the retry topic."""
+        event_label = get_event_label(event)
+        headers = headers_as_dict(event)
+
+        try:
+            type_ = get_header_value(header_name="type", headers=headers)
+            correlation_id = get_header_value(
+                header_name="correlation_id", headers=headers
+            )
+        except EventHeaderNotFoundError as err:
+            logging.warning("Ignored an event: %s. %s", event_label, err.args[0])
+            # acknowledge event receipt
+            await self._consumer.commit()
+            return
+
+        original_topic = event.value.get(ORIGINAL_TOPIC_FIELD, "")
+        if not original_topic:
+            error = RuntimeError(
+                "Tried to publish event to the retry topic, but the original topic was"
+                + " not found in the payload. This should be populated automatically."
+            )
+            logging.critical(error, extra={"payload": event.value})
+            raise error
+
+        async with set_correlation_id(correlation_id):
+            await self._publisher.publish(
+                payload=event.value,
+                type_=type_,
+                topic=self._dlq_retry_topic,
+                key=event.key,
+            )
+            logging.info(
+                "Published an event to the retry topic '%s'", self._dlq_retry_topic
+            )
+
+    async def run(self, ignore: bool = False) -> None:
+        """
+        Start consuming events and passing them down to the translator.
+        It will return after handling one event.
+        If `ignore` is True, the event will be ignored.
+        Otherwise, the event will be published to the retry topic.
+        """
+        event = await self._consumer.__anext__()
+        if not ignore:
+            await self._publish_to_retry(event)

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -170,7 +170,7 @@ class KafkaEventSubscriber(InboundProviderBase):
         dlq_publisher: Optional[EventPublisherProtocol] = None,
     ):
         """
-        Setup and teardown KafkaRetrySubscriber instance with some config params.
+        Setup and teardown KafkaEventSubscriber instance with some config params.
 
         Args:
             config:
@@ -457,7 +457,7 @@ class KafkaDLQSubscriber(InboundProviderBase):
         dlq_publisher: EventPublisherProtocol,
     ):
         """
-        Setup and teardown KafkaEventPublisher instance with some config params.
+        Setup and teardown KafkaDLQSubscriber instance with some config params.
 
         Args:
         - `config`:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -161,7 +161,8 @@ class OriginalTopicError(RuntimeError):
     """Raised when the original topic is missing from the event."""
 
     def __init__(self, *, event_label: str):
-        super().__init__(f"Unable to get original topic from event: {event_label}.")
+        msg = f"Unable to get original topic from event: {event_label}."
+        super().__init__(msg)
 
 
 class KafkaEventSubscriber(InboundProviderBase):
@@ -171,9 +172,8 @@ class KafkaEventSubscriber(InboundProviderBase):
         """Raised when an event has been retried the maximum number of times."""
 
         def __init__(self, *, event_type: str):
-            message = f"The maximum number of retries has been reached for '{
-                event_type}' event."
-            super().__init__(message)
+            msg = f"All retries exhausted for '{event_type}' event."
+            super().__init__(msg)
 
     @classmethod
     @asynccontextmanager

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -43,7 +43,7 @@ from hexkit.providers.akafka.provider.utils import (
     generate_ssl_context,
 )
 
-ORIGINAL_TOPIC_FIELD = "_original_topic"
+ORIGINAL_TOPIC_FIELD = "original_topic"
 
 
 class ConsumerEvent(Protocol):

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -404,7 +404,10 @@ class KafkaEventSubscriber(InboundProviderBase):
         if not correlation_id:
             errors.append("correlation_id is empty")
         if event.topic in (self._retry_topic, self._dlq_topic):
-            errors.append(f"topic '{event.topic}' is reserved for internal use")
+            errors.append(
+                f"original_topic header cannot be {self._retry_topic} or"
+                + f" {self._dlq_topic}. Value: '{event.topic}'"
+            )
         elif not event.topic:
             errors.append(
                 "topic is empty"

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -464,7 +464,8 @@ class KafkaDLQSubscriber(InboundProviderBase):
             Config parameters needed for connecting to Apache Kafka.
         - `dlq_publisher`:
             running instance of publishing provider that implements the
-            EventPublisherProtocol, such as KafkaEventPublisher.
+            EventPublisherProtocol, such as KafkaEventPublisher. It is used to publish
+            events to the configured retry topic.
         - `kafka_consumer_cls`:
             Overwrite the used Kafka consumer class . Only intended for unit testing.
         """

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -485,9 +485,7 @@ def validate_dlq_headers(event: ConsumerEvent) -> None:
     """
     headers = headers_as_dict(event)
     expected_headers = ["type", "correlation_id", ORIGINAL_TOPIC_FIELD]
-    invalid_headers = [
-        key for key in expected_headers if key not in headers or not headers[key]
-    ]
+    invalid_headers = [key for key in expected_headers if not headers.get(key, None)]
     if invalid_headers:
         error_msg = f"Missing or empty headers: {', '.join(invalid_headers)}"
         raise DLQValidationError(event=event, error=error_msg)

--- a/src/hexkit/providers/akafka/testutils.py
+++ b/src/hexkit/providers/akafka/testutils.py
@@ -43,7 +43,6 @@ from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.akafka.provider import (
     ConsumerEvent,
     KafkaEventPublisher,
-    get_header_value,
     headers_as_dict,
 )
 from hexkit.providers.akafka.testcontainer import DEFAULT_IMAGE as KAFKA_IMAGE
@@ -330,7 +329,7 @@ class EventRecorder:
         recorded_events: list[RecordedEvent] = []
         for raw_event in raw_events:
             headers = headers_as_dict(raw_event)
-            type_ = get_header_value("type", headers=headers)
+            type_ = headers.get("type", "")
             del headers["type"]
 
             recorded_event = RecordedEvent(

--- a/src/hexkit/providers/akafka/testutils.py
+++ b/src/hexkit/providers/akafka/testutils.py
@@ -20,7 +20,7 @@ Please note, only use for testing purposes.
 """
 
 import json
-from collections.abc import AsyncGenerator, Generator, Sequence
+from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
@@ -406,10 +406,18 @@ class KafkaFixture:
         self.publisher = publisher
 
     async def publish_event(
-        self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: Ascii = "test"
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        topic: Ascii,
+        key: Ascii = "test",
+        headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """A convenience method to publish a test event."""
-        await self.publisher.publish(payload=payload, type_=type_, key=key, topic=topic)
+        await self.publisher.publish(
+            payload=payload, type_=type_, key=key, topic=topic, headers=headers
+        )
 
     def record_events(
         self, *, in_topic: Ascii, capture_headers: bool = False

--- a/src/hexkit/providers/s3/testutils/_utils.py
+++ b/src/hexkit/providers/s3/testutils/_utils.py
@@ -44,7 +44,7 @@ class FileObject(BaseModel):
     bucket_id: str
     object_id: str
 
-    @computed_field  # type: ignore [misc]
+    @computed_field  # type: ignore [prop-decorator]
     @property
     def content(self) -> bytes:
         """Extract the content from the file at the provided path"""
@@ -53,7 +53,7 @@ class FileObject(BaseModel):
         with open(self.file_path, "rb") as file:
             return file.read()
 
-    @computed_field  # type: ignore [misc]
+    @computed_field  # type: ignore [prop-decorator]
     @property
     def md5(self) -> str:
         """Calculate the md5 hash of the content"""

--- a/src/hexkit/providers/testing/eventpub.py
+++ b/src/hexkit/providers/testing/eventpub.py
@@ -77,7 +77,7 @@ class InMemEventPublisher(EventPublisherProtocol):
         """Initialize with existing event_store or let it create a new one."""
         self.event_store = event_store if event_store else InMemEventStore()
 
-    async def _publish_validated(  # noqa: PLR0913
+    async def _publish_validated(
         self,
         *,
         payload: JsonObject,

--- a/src/hexkit/providers/testing/eventpub.py
+++ b/src/hexkit/providers/testing/eventpub.py
@@ -21,6 +21,7 @@ ATTENTION: For testing purposes only.
 """
 
 from collections import defaultdict, deque
+from collections.abc import Mapping
 from typing import NamedTuple, Optional
 
 from hexkit.custom_types import JsonObject
@@ -76,8 +77,14 @@ class InMemEventPublisher(EventPublisherProtocol):
         """Initialize with existing event_store or let it create a new one."""
         self.event_store = event_store if event_store else InMemEventStore()
 
-    async def _publish_validated(
-        self, *, payload: JsonObject, type_: str, key: str, topic: str
+    async def _publish_validated(  # noqa: PLR0913
+        self,
+        *,
+        payload: JsonObject,
+        type_: str,
+        key: str,
+        topic: str,
+        headers: Mapping[str, str],
     ) -> None:
         """Publish an event with already validated topic and type.
 

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -69,7 +69,7 @@ def assert_logged(
     - `records`: The log records to check (usually `caplog.records`)
     - `parse`: Whether to parse the message with the arguments from the log record.
 
-    If a match is found, the parsed message is return (regardless of the value of `parse`).
+    If a match is found, the parsed message is returned (regardless of the value of `parse`).
     """
     for i, record in enumerate(records):
         msg_to_inspect = str(record.msg) % record.args if parse else record.msg

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -69,7 +69,8 @@ def assert_logged(
     - `records`: The log records to check (usually `caplog.records`)
     - `parse`: Whether to parse the message with the arguments from the log record.
 
-    If a match is found, the parsed message is returned (regardless of the value of `parse`).
+    If a match is found, the parsed message is returned (regardless of the value of
+    `parse`) and removed from the records list.
     """
     for i, record in enumerate(records):
         msg_to_inspect = str(record.msg) % record.args if parse else record.msg

--- a/tests/fixtures/utils.py
+++ b/tests/fixtures/utils.py
@@ -18,6 +18,7 @@
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 import pytest
 import yaml
@@ -49,3 +50,58 @@ def root_logger_reset():
     # reset level and handlers
     root.setLevel(original_level)
     root.handlers = root_handlers
+
+
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL", "FATAL"]
+
+
+def assert_logged(
+    level: LogLevel,
+    message: str,
+    records: list[logging.LogRecord],
+    parse: bool = True,
+) -> str:
+    """Assert that a log message was logged with the given level and message.
+
+    Args:
+    - `level`: The log level to check for.
+    - `message`: The message to check for.
+    - `records`: The log records to check (usually `caplog.records`)
+    - `parse`: Whether to parse the message with the arguments from the log record.
+
+    If a match is found, the parsed message is return (regardless of the value of `parse`).
+    """
+    for i, record in enumerate(records):
+        msg_to_inspect = str(record.msg) % record.args if parse else record.msg
+        if record.levelname == level and msg_to_inspect == message:
+            del records[i]
+            return msg_to_inspect if parse else str(record.msg) % record.args
+    else:
+        assert False, f"Log message not found: {level} - {message}"
+
+
+def assert_not_logged(
+    level: LogLevel,
+    message: str,
+    records: list[logging.LogRecord],
+    parse: bool = True,
+):
+    """Assert that a log message was not logged with the given level and message.
+
+    Args:
+    - `level`: The log level to check for.
+    - `message`: The message to check for.
+    - `records`: The log records to check (usually `caplog.records`)
+    - `parse`: Whether to parse the message with the arguments from the log record.
+    """
+    for record in records:
+        msg_to_inspect = str(record.msg) % record.args if parse else record.msg
+        if record.levelname == level and msg_to_inspect == message:
+            assert False, f"Log message found: {level} - {message}"
+
+
+@pytest.fixture(name="caplog_debug")
+def caplog_debug_fixture(caplog):
+    """Convenience fixture to set the log level of caplog to debug for a test."""
+    caplog.set_level(logging.DEBUG)
+    yield caplog

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -174,7 +174,7 @@ async def test_consumer_commit_mode(kafka: KafkaFixture):
     """Verify the consumer implementation behavior matches expectations."""
     type_ = "test_type"
     topic = "test_topic"
-    type_ = "test_type"
+
     partition = TopicPartition(topic, 0)
 
     error_message = "Consumer crashed successfully."

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -174,7 +174,7 @@ async def test_context_var_setter():
         (VALID_CORRELATION_ID, False, None),
         ("invalid", True, InvalidCorrelationIdError),
         ("invalid", False, None),
-        ("", True, InvalidCorrelationIdError),
+        ("", True, None),
         ("", False, None),
     ],
 )

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -230,7 +230,7 @@ def test_config_validation(
 @pytest.mark.asyncio()
 async def test_original_topic_is_preserved(kafka: KafkaFixture):
     """Ensure the original topic is preserved when it reaches the DLQ subscriber and
-    when it comes back to the Retry subscriber.
+    when it comes back to the subscriber.
 
     Consume a failing event, send to DLQ, consume from DLQ, send to Retry, consume from
     Retry, and check the original topic.

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -215,7 +215,7 @@ def test_config_validation(
 
     Errors should occur:
     1. Anytime max_retries is < 0
-    2. If retry and dlq topics are the same (non-empty)
+    2. If retry and DLQ topics are the same (non-empty)
     3. If the DLQ is enabled but the topics are not set (either or both)
     """
     with pytest.raises(ValueError) if error else nullcontext():
@@ -500,7 +500,7 @@ async def test_dlq_subscriber_ignore(kafka: KafkaFixture, caplog_debug):
 
 @pytest.mark.asyncio()
 async def test_no_retries_no_dlq_original_error(kafka: KafkaFixture, caplog_debug):
-    """Test that not using the dlq and configuring 0 retries results in failures that
+    """Test that not using the DLQ and configuring 0 retries results in failures that
     propagate the underlying error to the provider.
     """
     config = make_config(kafka.config, enable_dlq=False)
@@ -580,7 +580,7 @@ async def test_outbox_with_dlq(kafka: KafkaFixture, event_type: str):
 @pytest.mark.asyncio
 async def test_kafka_event_subcriber_construction(caplog):
     """Test construction of the KafkaEventSubscriber, ensuring an error is raised if
-    the dlq is enabled but no provider is used.
+    the DLQ is enabled but no provider is used.
     """
     config = make_config()
     translator = FailSwitchTranslator(

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -297,20 +297,20 @@ async def test_invalid_retries_left(kafka: KafkaFixture, caplog_debug):
     async with KafkaEventSubscriber.construct(
         config=config, translator=translator, dlq_publisher=dummy_publisher
     ) as retry_sub:
-        with pytest.raises(ValueError):
+        with pytest.raises(KafkaEventSubscriber.RetriesLeftError):
             await retry_sub._retry_event(event=TEST_EVENT, retries_left=-1)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(KafkaEventSubscriber.RetriesLeftError):
             await retry_sub._retry_event(event=TEST_EVENT, retries_left=3)
 
     assert_logged(
         "ERROR",
-        "Invalid value for retries_left: -1 (should be between 1 and 2)",
+        "Invalid value for retries_left: -1 (should be between 1 and 2, inclusive).",
         caplog_debug.records,
     )
     assert_logged(
         "ERROR",
-        "Invalid value for retries_left: 3 (should be between 1 and 2)",
+        "Invalid value for retries_left: 3 (should be between 1 and 2, inclusive).",
         caplog_debug.records,
     )
 

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -281,7 +281,7 @@ async def test_original_topic_is_preserved(kafka: KafkaFixture):
         await event_subscriber.run(forever=False)
 
     # Make sure the event received by the translator is identical to the original
-    # This means the original topic is preserved and `_original_topic` is removed
+    # This means the original topic is preserved and `original_topic` is removed
     assert translator.failures == [TEST_EVENT]
     assert translator.successes == [TEST_EVENT]
 
@@ -478,7 +478,7 @@ async def test_dlq_subscriber_ignore(kafka: KafkaFixture, caplog_debug):
     """Test what happens when a DLQ Subscriber is instructed to ignore an event."""
     config = make_config(kafka.config)
 
-    # make an event without the _original_topic field in the payload
+    # make an event without the original_topic field in the payload
     event = ExtractedEventInfo(
         payload={"test_id": "123456", ORIGINAL_TOPIC_FIELD: "test-topic"},
         type_="test_type",

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -1,0 +1,551 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Dead Letter Queue (DLQ) event subscribers"""
+
+from contextlib import nullcontext
+from copy import deepcopy
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel
+
+from hexkit.custom_types import Ascii, JsonObject
+from hexkit.protocols.daosub import DaoSubscriberProtocol
+from hexkit.protocols.eventpub import EventPublisherProtocol
+from hexkit.protocols.eventsub import EventSubscriberProtocol
+from hexkit.providers.akafka import KafkaConfig
+from hexkit.providers.akafka.provider.daosub import KafkaOutboxSubscriber
+from hexkit.providers.akafka.provider.eventsub import (
+    ORIGINAL_TOPIC_FIELD,
+    ExtractedEvent,
+    KafkaDLQSubscriber,
+    KafkaEventSubscriber,
+    OriginalTopicError,
+)
+from hexkit.providers.akafka.testutils import (  # noqa: F401
+    KafkaFixture,
+    kafka_container_fixture,
+    kafka_fixture,
+)
+
+TEST_EVENT = ExtractedEvent(
+    payload={"key": "value"},
+    type_="test_type",
+    topic="test-topic",
+    key="key",
+)
+
+
+class OutboxDto(BaseModel):
+    """Dummy DTO model to use for outbox tests"""
+
+    user_id: str
+    email: str
+    name: str
+
+
+OUTBOX_EVENT_UPSERT = ExtractedEvent(
+    payload=OutboxDto(
+        user_id="123456", email="test@test.com", name="Test User"
+    ).model_dump(),
+    topic="users",
+    type_="upserted",
+    key="123456",
+)
+
+OUTBOX_EVENT_DELETE = deepcopy(OUTBOX_EVENT_UPSERT)
+OUTBOX_EVENT_DELETE.type_ = "deleted"
+
+
+class FailSwitchTranslator(EventSubscriberProtocol):
+    """Event translator that can be set to fail or collect events."""
+
+    fail: bool
+    failures: list[ExtractedEvent]
+    successes: list[ExtractedEvent]
+    topics_of_interest: list[str]
+    types_of_interest: list[str]
+
+    def __init__(
+        self,
+        *,
+        topics_of_interest: list[str],
+        types_of_interest: list[str],
+        fail: bool = False,
+    ):
+        self.fail = fail
+        self.successes = []
+        self.failures = []
+        self.topics_of_interest = topics_of_interest
+        self.types_of_interest = types_of_interest
+
+    async def _consume_validated(
+        self,
+        *,
+        payload: JsonObject,
+        type_: str,
+        topic: str,
+        key: str,
+    ) -> None:
+        """Add event to failures or successful list depending on `fail`.
+
+        Raises RuntimeError if `fail` is True.
+        """
+        event = ExtractedEvent(payload=payload, type_=type_, topic=topic, key=key)
+        if self.fail:
+            self.failures.append(event)
+            raise RuntimeError("Destined to fail.")
+        self.successes.append(event)
+
+
+class FailSwitchOutboxTranslator(DaoSubscriberProtocol):
+    """Translator for the outbox event."""
+
+    event_topic: str = "users"
+    dto_model: type[BaseModel] = OutboxDto
+    fail: bool = False
+    upsertions: list[ExtractedEvent]
+    deletions: list[str]
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.upsertions = []
+        self.deletions = []
+        self.fail = fail
+
+    async def changed(self, resource_id: str, update: OutboxDto) -> None:
+        """Dummy"""
+        self.upsertions.append(
+            ExtractedEvent(
+                payload=update.model_dump(),
+                type_="upserted",
+                topic=self.event_topic,
+                key=resource_id,
+            )
+        )
+        if self.fail:
+            raise RuntimeError("Destined to fail.")
+
+    async def deleted(self, resource_id: str) -> None:
+        """Dummy"""
+        self.deletions.append(resource_id)
+        if self.fail:
+            raise RuntimeError("Destined to fail.")
+
+
+class DummyPublisher(EventPublisherProtocol):
+    """Dummy class to intercept publishing"""
+
+    published: list[ExtractedEvent]
+
+    def __init__(self) -> None:
+        self.published = []
+
+    async def _publish_validated(
+        self, *, payload: JsonObject, type_: Ascii, key: Ascii, topic: Ascii
+    ) -> None:
+        self.published.append(
+            ExtractedEvent(payload=payload, type_=type_, topic=topic, key=key)
+        )
+
+
+def make_config(
+    kafka_config: Optional[KafkaConfig] = None,
+    *,
+    retry_topic: str = "retry",
+    dlq_topic: str = "dlq",
+    max_retries: int = 0,
+    enable_dlq: bool = True,
+) -> KafkaConfig:
+    """Convenience method to merge kafka fixture config with provided DLQ values."""
+    return KafkaConfig(
+        service_name=getattr(kafka_config, "service_name", "test"),
+        service_instance_id=getattr(kafka_config, "service_instance_id", "test"),
+        kafka_servers=getattr(kafka_config, "kafka_servers", ["localhost:9092"]),
+        kafka_dlq_topic=dlq_topic,
+        kafka_retry_topic=retry_topic,
+        kafka_max_retries=max_retries,
+        kafka_enable_dlq=enable_dlq,
+    )
+
+
+@pytest.mark.parametrize(
+    "retry_topic, dlq_topic, max_retries, enable_dlq, error",
+    [
+        ("retry", "dlq", 0, True, False),
+        ("retry", "dlq", 1, True, False),
+        ("retry", "dlq", -1, True, True),
+        ("retry", "retry", 0, True, True),
+        ("retry", "retry", 0, False, True),
+        ("", "", 0, False, False),
+        ("", "dlq", 0, False, False),
+        ("retry", "dlq", 0, False, False),
+        ("retry", "", 0, True, True),
+        ("", "dlq", 0, True, True),
+        ("", "", 0, True, True),
+    ],
+)
+def test_config_validation(
+    retry_topic: str,
+    dlq_topic: str,
+    max_retries: int,
+    enable_dlq: bool,
+    error: bool,
+):
+    """Test for config validation.
+
+    Errors should occur:
+    1. Anytime max_retries is < 0
+    2. If retry and dlq topics are the same (non-empty)
+    3. If the DLQ is enabled but the topics are not set (either or both)
+    """
+    with pytest.raises(ValueError) if error else nullcontext():
+        make_config(
+            retry_topic=retry_topic,
+            dlq_topic=dlq_topic,
+            max_retries=max_retries,
+            enable_dlq=enable_dlq,
+        )
+
+
+@pytest.mark.asyncio()
+async def test_original_topic_is_preserved(kafka: KafkaFixture):
+    """Ensure the original topic is preserved when it reaches the DLQ subscriber and
+    when it comes back to the Retry subscriber.
+
+    Consume a failing event, send to DLQ, consume from DLQ, send to Retry, consume from
+    Retry, and check the original topic.
+    """
+    config = make_config(kafka.config)
+
+    # Publish test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    # Create dummy translator and set it to auto-fail, then run the Retry subscriber
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"], fail=True
+    )
+    assert not translator.successes
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_sub:
+        assert not translator.failures
+        await retry_sub.run(forever=False)
+
+        # Run the DLQ subscriber, telling it to publish the event to the retry topic
+        async with KafkaDLQSubscriber.construct(
+            config=config, publisher=kafka.publisher
+        ) as dlq_sub:
+            await dlq_sub.run()
+
+        # Make sure the translator has nothing in the successful list, then run again
+        assert not translator.successes
+        translator.fail = False
+        await retry_sub.run(forever=False)
+
+    # Make sure the event received by the translator is identical to the original
+    # This means the original topic is preserved and `_original_topic` is removed
+    assert translator.failures == [TEST_EVENT]
+    assert translator.successes == [TEST_EVENT]
+
+
+@pytest.mark.parametrize("max_retries", [0, 1, 2])
+@pytest.mark.asyncio()
+async def test_max_retries_respected(kafka: KafkaFixture, max_retries: int):
+    """Ensure the retry limit is respected."""
+    config = make_config(kafka.config, max_retries=max_retries)
+
+    # Publish test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    # Create dummy translator and set it to auto-fail, then run the Retry subscriber
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"], fail=True
+    )
+    assert not translator.successes
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_sub:
+        assert not translator.failures
+        await retry_sub.run(forever=False)
+
+    # Verify that the event was retried twice after initial failure
+    assert translator.failures == [TEST_EVENT] * (max_retries + 1)
+
+
+@pytest.mark.parametrize("max_retries", [0, 1, 2])
+@pytest.mark.asyncio()
+async def test_send_to_dlq(kafka: KafkaFixture, max_retries: int):
+    """Ensure the event is sent to the DLQ topic when the retries are exhausted."""
+    config = make_config(kafka.config, max_retries=max_retries)
+
+    # Publish test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    # Set up dummies and consume the event
+    dummy_publisher = DummyPublisher()
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"], fail=True
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=dummy_publisher
+    ) as retry_sub:
+        translator.fail = True
+        await retry_sub.run(forever=False)
+
+    # Put together the expected event with the appended topic field
+    modified_payload = {**TEST_EVENT.payload}
+    modified_payload[ORIGINAL_TOPIC_FIELD] = TEST_EVENT.topic
+    modified_event = ExtractedEvent(
+        type_=TEST_EVENT.type_,
+        topic=config.kafka_dlq_topic,
+        key=TEST_EVENT.key,
+        payload=modified_payload,
+    )
+
+    # Verify that the event was sent to the DLQ topic just once and that it has
+    # the original topic field appended
+    assert dummy_publisher.published == [modified_event]
+
+
+@pytest.mark.asyncio()
+async def test_send_to_retry(kafka: KafkaFixture):
+    """Ensure the event is sent to the retry topic when the DLQ subscriber is instructed
+    to do so.
+    """
+    config = make_config(kafka.config)
+
+    # Publish event directly to DLQ Topic
+    failed_event_payload = {"test_id": "123456", ORIGINAL_TOPIC_FIELD: "test-topic"}
+
+    failed_event = ExtractedEvent(
+        payload=failed_event_payload,
+        type_="test_type",
+        topic=config.kafka_dlq_topic,
+        key="123456",
+    )
+
+    await kafka.publisher.publish(**vars(failed_event))
+
+    # Set up dummies and consume the event with the DLQ Subscriber
+    dummy_publisher = DummyPublisher()
+    async with KafkaDLQSubscriber.construct(
+        config=config, publisher=dummy_publisher
+    ) as dlq_sub:
+        assert not dummy_publisher.published
+        await dlq_sub.run(ignore=False)
+
+    # Verify that the event was sent to the retry topic
+    expected_event = ExtractedEvent(
+        payload=failed_event_payload,
+        type_="test_type",
+        topic=config.kafka_retry_topic,
+        key="123456",
+    )
+
+    assert dummy_publisher.published == [expected_event]
+
+
+@pytest.mark.asyncio()
+async def test_orig_topic_missing_dlq_sub(kafka: KafkaFixture):
+    """Test for errors when the _original_topic is missing from an event."""
+    config = make_config(kafka.config)
+
+    # make an event without the _original_topic field in the payload
+    event = ExtractedEvent(
+        payload={"test_id": "123456"},
+        type_="test_type",
+        topic=config.kafka_dlq_topic,
+        key="key",
+    )
+
+    # Publish that event directly to DLQ Topic, as if it had already failed
+    await kafka.publisher.publish(**vars(event))
+
+    # Set up dummies and consume the event with the DLQ Subscriber
+    dummy_publisher = DummyPublisher()
+    async with KafkaDLQSubscriber.construct(
+        config=config, publisher=dummy_publisher
+    ) as dlq_sub:
+        assert not dummy_publisher.published
+
+        # Expect the subscriber to raise an error because the _original_topic field is
+        # missing
+        with pytest.raises(RuntimeError):
+            await dlq_sub.run(ignore=False)
+
+
+@pytest.mark.asyncio()
+async def test_orig_topic_missing_retry_sub(kafka: KafkaFixture):
+    """Test for errors when the _original_topic is missing from an event consumed by
+    a KafkaRetrySubscriber.
+    """
+    config = make_config(kafka.config)
+
+    # make an event without the _original_topic field in the payload
+    event = ExtractedEvent(
+        payload={"test_id": "123456"},
+        type_="test_type",
+        topic=config.kafka_retry_topic,
+        key="key",
+    )
+
+    # Publish that event directly to DLQ Topic, as if it had already failed
+    await kafka.publisher.publish(**vars(event))
+
+    # Set up dummies and consume the event with the DLQ Subscriber
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"]
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_subscriber:
+        assert not translator.failures or translator.successes
+
+        # Expect the subscriber to raise an error because the _original_topic field is
+        # missing
+        with pytest.raises(OriginalTopicError):
+            await retry_subscriber.run(forever=False)
+
+
+@pytest.mark.asyncio()
+async def test_dlq_subscriber_ignore(kafka: KafkaFixture):
+    """Test what happens when a DLQ Subscriber is instructed to ignore an event."""
+    config = make_config(kafka.config)
+
+    # make an event without the _original_topic field in the payload
+    event = ExtractedEvent(
+        payload={"test_id": "123456", ORIGINAL_TOPIC_FIELD: "test-topic"},
+        type_="test_type",
+        topic=config.kafka_dlq_topic,
+        key="key",
+    )
+
+    # Publish that event directly to DLQ Topic, as if it had already failed
+    await kafka.publisher.publish(**vars(event))
+
+    # Set up dummies and consume the event with the DLQ Subscriber
+    dummy_publisher = DummyPublisher()
+    async with KafkaDLQSubscriber.construct(
+        config=config, publisher=dummy_publisher
+    ) as dlq_sub:
+        assert not dummy_publisher.published
+        await dlq_sub.run(ignore=True)
+
+    # Assert that the event was not published to the retry topic
+    assert not dummy_publisher.published
+
+
+@pytest.mark.asyncio()
+async def test_successful_event(kafka: KafkaFixture):
+    """Happy path for a successful event."""
+    config = make_config(kafka.config)
+
+    # publish the test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"]
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_sub:
+        assert not translator.successes
+        await retry_sub.run(forever=False)
+        assert translator.successes == [TEST_EVENT]
+
+
+@pytest.mark.asyncio()
+async def test_no_retries_no_dlq_original_error(kafka: KafkaFixture):
+    """Test that not using the dlq and configuring 0 retries results in failures that
+    propagate the underlying error to the provider.
+    """
+    config = make_config(kafka.config, enable_dlq=False)
+
+    # publish the test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"], fail=True
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_sub:
+        assert not translator.successes
+        with pytest.raises(RuntimeError, match="Destined to fail."):
+            await retry_sub.run(forever=False)
+        assert not translator.successes
+        assert translator.failures == [TEST_EVENT]
+
+
+@pytest.mark.asyncio()
+@pytest.mark.xfail(reason="RetriesExhaustedError is not raised unless max_retries > 0")
+async def test_no_retries_no_dlq_retries_error(kafka: KafkaFixture):
+    """Test that not using the dlq and configuring 0 retries does NOT raise a
+    RetriesExhaustedError.
+    """
+    config = make_config(kafka.config, max_retries=1, enable_dlq=False)
+
+    # publish the test event
+    await kafka.publisher.publish(**vars(TEST_EVENT))
+
+    translator = FailSwitchTranslator(
+        topics_of_interest=["test-topic"], types_of_interest=["test_type"], fail=True
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, publisher=kafka.publisher
+    ) as retry_sub:
+        assert not translator.successes
+        with pytest.raises(KafkaEventSubscriber.RetriesExhaustedError):
+            await retry_sub.run(forever=False)
+        assert not translator.successes
+        assert translator.failures == [TEST_EVENT]
+
+
+@pytest.mark.parametrize("event_type", ["upserted", "deleted"])
+@pytest.mark.asyncio()
+async def test_outbox_with_dlq(kafka: KafkaFixture, event_type: str):
+    """Ensure that the DLQ lifecycle works with the KafkaOutboxSubscriber."""
+    config = make_config(kafka.config)
+
+    translator = FailSwitchOutboxTranslator(fail=True)
+    list_to_check = (
+        translator.upsertions if event_type == "upserted" else translator.deletions
+    )
+
+    event = OUTBOX_EVENT_UPSERT if event_type == "upserted" else OUTBOX_EVENT_DELETE
+
+    # publish the test event
+    await kafka.publisher.publish(**vars(event))
+
+    # Run the outbox subscriber and expect it to fail
+    async with KafkaOutboxSubscriber.construct(
+        config=config, publisher=kafka.publisher, translators=[translator]
+    ) as outbox_sub:
+        assert not list_to_check
+        await outbox_sub.run(forever=False)
+        assert list_to_check == [event] if event_type == "upserted" else [event.key]
+
+        # Consume event from the DLQ topic, publish to retry topic
+        async with KafkaDLQSubscriber.construct(
+            config=config, publisher=kafka.publisher
+        ) as dlq_sub:
+            await dlq_sub.run()
+
+        # Retry the event after clearing the list
+        list_to_check.clear()  # type: ignore
+        translator.fail = False
+        assert not list_to_check
+        await outbox_sub.run(forever=False)
+        assert list_to_check == [event] if event_type == "upserted" else [event.key]

--- a/tests/unit/test_eventpub.py
+++ b/tests/unit/test_eventpub.py
@@ -31,7 +31,7 @@ class FakePublisher(EventPublisherProtocol):
     any logic.
     """
 
-    async def _publish_validated(self, *, payload, type_, key, topic) -> None:
+    async def _publish_validated(self, *, payload, type_, key, topic, headers) -> None:
         pass
 
 


### PR DESCRIPTION
>  _UPDATE August 1, 2024_: Services implementing the `EventPublisherProtocol` will have to add the `headers` parameter to `_publish_validated`. Currently, this only affects the [auth-service](https://github.com/ghga-de/auth-service/blob/cd4dbb13146c6356a242b9abf6fbb4c2c09a217f/tests/unit/user_management/user_registry/test_event_pub.py#L55), [access-request-service](https://github.com/ghga-de/access-request-service/blob/26cb9eca1441a4185c06a5a4ccb339043b1a36c0/tests/test_event_pub.py#L43), and [metldata](https://github.com/ghga-de/metldata/blob/daed73aa5ad601e2c0589fc2c68ce69a0e07ae3d/src/metldata/event_handling/event_handling.py#L101).

This PR adds a _not-quite_ backwards-compatible way to handle (retry, dismiss) Kafka events that fail at some point while being processed by the translator. Some config options are added to manage this functionality, and in their default state they change nothing: events that fail will crash the service and be retried upon restart. 

Changes introduced are summarized below:

**New Config Fields:**
- `kafka_dlq_topic`: Name of the topic for events when they initially fail
- `kafka_retry_topic`: Name of the topic for failed events that are to be requeued
- `kafka_max_retries`: The number of times to retry a failed event before sending it to the DLQ topic, if enabled
- `kafka_enable_dlq`: Whether or not to use the DLQ
- `kafka_retry_backoff`: The number of seconds to wait between "immediate" retries. This value is doubled with each subsequent retry.

**New Functionality:**
- Retry events after a pause. Configuring `kafka_max_retries` will set the number of times to directly retry a failed event after waiting `kafka_retry_backoff` seconds. The default number of retries is 0, which will propagate the error just like `hexkit <4`. If `kafka_max_retries` is greater than 0, final failure will result in a `RetriesExhaustedError`.
- Publish failed events to a dead letter queue automatically. Set `kafka_dlq_topic`, `kafka_retry_topic`, and `kafka_enable_dlq` to use the DLQ functionality and publish failed events to the configured DLQ topic. The original topic name is preserved by appending it to the **event** ~~payload~~ **headers** in a field named `_original_topic`. When an event is consumed from the configured `kafka_retry_topic`, its headers will be inspected to find the original topic (so the service knows how to treat the event). For events in `kafka_retry_topic`, having no `_original_topic` header will get them ignored. The same goes for `kafka_dlq_topic` if using the default `process_dlq_event` function.
- Ignore (discard) events in a DLQ topic or send them to a retry topic. The `KafkaDLQSubscriber` class is a dedicated provider that listens to the configured DLQ topic. When run, the event is sent to the configured retry topic or, if `ignore=True` is used, the event is simply ignored. This class does not have to be used by a particular service, and could be used by a dedicated DLQ triage service. Additionally, there is a `process_dlq_event` parameter that takes a callable. This callback is executed when `ignore=False`, and can be a simple standalone function or a method on a complex, configurable class instance. Through `process_dlq_event`, events can be modified or examined as needed before being republished or discarded.
- Encapsulate the way we use `ConsumerEvent` details with `ExtractedEventInfo` (open to naming suggestions). The class will contain the type_, topic, key, payload, and dict-form decoded headers from `ConsumerEvent`, and can be instantiated both with kwargs and a `ConsumerEvent`-compatible object.

> [!NOTE]
> The immediate retry and dlq mechanisms are independent. Events can be published to the dead letter queue with 0 retries, retried a few times and never sent to the DLQ, etc.

## Adoption
For existing services, no changes are needed beyond adjusting the configuration parameters and adding a `KafkaEventPublisher` to the `KafkaEventSubscriber.construct()` or `KafkaOutboxSubscriber.construct()` calls (e.g. in the injection module). For deployment, at least one DLQ and one Retry topic will need to be established (maybe one each for all services is enough to begin with?)

To add the ability to move events from a DLQ topic to a Retry topic, there needs to be a way to invoke a `KafkaDLQSubscriber`, as illustrated below. We need to discuss how best to do this: a dedicated DLQ service? CLI command on each kafka-consuming service? Where applicable, events can be manually sent to a retry queue with Kafka UI as long as `_original_topic` is placed in the headers.

## Example Usage for DLQ Subscriber and Process Function
```python
from typing import Optional

from hexkit.providers.akafka.provider import (
    ConsumerEvent,
    ExtractedEventInfo,
    KafkaDLQSubscriber,
    KafkaEventPublisher,
    validate_dlq_headers,
)

from ifrs.config import Config

# This is an example of a callback function that can be passed to the KafkaDLQSubscriber
# Here it's very simple, but it could also be a complex function on a config-driven class.
async def fix_dlq_event(event: ConsumerEvent) -> Optional[ExtractedEventInfo]:
    """Update old events for config changes or pass event unchanged."""
    validate_dlq_headers(event)
    event_info = ExtractedEventInfo(event)
    if event.topic == "uploads" and event_info.headers["type"] == "outdated_type":
        event_info.headers["type"] = "new_type"
    return event_info

# This is an example of an entrypoint function that could be triggered for DLQ event resolution
async def resolve_dlq_event(ignore: bool = False):
    """Requeue or discard a DLQ event."""
    config = Config()
    async with (
        KafkaEventPublisher.construct(config=config) as publisher,
        KafkaDLQSubscriber.construct(
            config=config, dlq_publisher=publisher, process_dlq_event=fix_dlq_event
        ) as dlq_subscriber,
    ):
        await dlq_subscriber.run(ignore)
```