### PR TITLE
Configure event size limit (GSI-939)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "3.4.1"
+version = "3.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "3.4.1"
+version = "3.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -76,3 +76,9 @@ class KafkaConfig(BaseSettings):
             + " newly correlation ID will be generated and used in the event header."
         ),
     )
+    kafka_max_message_size: int = Field(
+        default=1048576,
+        description="The largest message size that can be transmitted, in bytes. Only"
+        + " services that have a need to send/receive larger messages should set this.",
+        examples=[0, 16000000],
+    )

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -77,8 +77,8 @@ class KafkaConfig(BaseSettings):
         ),
     )
     kafka_max_message_size: PositiveInt = Field(
-        default=1048576,
+        default=1024 * 1024,  # 1 MiB
         description="The largest message size that can be transmitted, in bytes. Only"
         + " services that have a need to send/receive larger messages should set this.",
-        examples=[1048576, 16000000],
+        examples=[1024 * 1024, 16 * 1024 * 1024],
     )

--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -18,7 +18,7 @@
 
 from typing import Literal
 
-from pydantic import Field, SecretStr
+from pydantic import Field, PositiveInt, SecretStr
 from pydantic_settings import BaseSettings
 
 
@@ -76,9 +76,9 @@ class KafkaConfig(BaseSettings):
             + " newly correlation ID will be generated and used in the event header."
         ),
     )
-    kafka_max_message_size: int = Field(
+    kafka_max_message_size: PositiveInt = Field(
         default=1048576,
         description="The largest message size that can be transmitted, in bytes. Only"
         + " services that have a need to send/receive larger messages should set this.",
-        examples=[0, 16000000],
+        examples=[1048576, 16000000],
     )

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -54,6 +54,7 @@ class KafkaProducerCompatible(Protocol):
         client_id: str,
         key_serializer: Callable[[Any], bytes],
         value_serializer: Callable[[Any], bytes],
+        max_request_size: int,
     ):
         """
         Initialize the producer with some config params.
@@ -67,6 +68,8 @@ class KafkaProducerCompatible(Protocol):
                 Function to serialize the keys into bytes.
             value_serializer:
                 Function to serialize the values into bytes.
+            max_request_size:
+                Maximum sendable message size.
         """
         ...
 
@@ -116,6 +119,7 @@ class KafkaEventPublisher(EventPublisherProtocol):
             value_serializer=lambda event_value: json.dumps(event_value).encode(
                 "ascii"
             ),
+            max_request_size=config.kafka_max_message_size,
         )
 
         try:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -90,6 +90,7 @@ class KafkaConsumerCompatible(Protocol):
         enable_auto_commit: bool,
         key_deserializer: Callable[[bytes], str],
         value_deserializer: Callable[[bytes], str],
+        max_partition_fetch_bytes: int,
     ):
         """
         Initialize the consumer with some config params.
@@ -108,6 +109,8 @@ class KafkaConsumerCompatible(Protocol):
                 Function to deserialize the keys into strings.
             value_serializer:
                 Function to deserialize the values into strings.
+            max_partition_fetch_bytes:
+                Maximum receivable message size
         """
         ...
 
@@ -176,6 +179,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             value_deserializer=lambda event_value: json.loads(
                 event_value.decode("ascii")
             ),
+            max_partition_fetch_bytes=config.kafka_max_message_size,
         )
         try:
             await consumer.start()

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -402,7 +402,7 @@ class MongoKafkaConfig(MongoDbConfig, KafkaConfig):
     @classmethod
     def validate_max_message_size(cls, value: int) -> int:
         """Validate the maximum message size."""
-        if value > 2**24:
+        if value > 2**24:  # 16 MiB
             logging.warning(
                 f"Max message size ({value}) exceeds the 16 MiB document size limit for MongoDB!"
             )

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -402,9 +402,9 @@ class MongoKafkaConfig(MongoDbConfig, KafkaConfig):
     @classmethod
     def validate_max_message_size(cls, value: int) -> int:
         """Validate the maximum message size."""
-        if value > 16_000_000:
+        if value > 2**24:
             logging.warning(
-                f"Max message size ({value}) exceeds the 16 MB document size limit for MongoDB!"
+                f"Max message size ({value}) exceeds the 16 MiB document size limit for MongoDB!"
             )
         return value
 

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -20,6 +20,7 @@ Require dependencies of the `akafka` and `mongodb` extras.
 """
 
 import json
+import logging
 from collections.abc import AsyncIterator, Awaitable, Collection, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, contextmanager
 from typing import Any, Callable, Generic, Optional
@@ -27,6 +28,7 @@ from typing import Any, Callable, Generic, Optional
 from aiokafka import AIOKafkaProducer
 from motor.core import AgnosticCollection
 from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import field_validator
 
 from hexkit.correlation import get_correlation_id, set_correlation_id
 from hexkit.custom_types import JsonObject
@@ -395,6 +397,16 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
 
 class MongoKafkaConfig(MongoDbConfig, KafkaConfig):
     """Config parameters and their defaults."""
+
+    @field_validator("kafka_max_message_size", mode="after")
+    @classmethod
+    def validate_max_message_size(cls, value: int) -> int:
+        """Validate the maximum message size."""
+        if value > 16_000_000:
+            logging.warning(
+                f"Max message size ({value}) exceeds the 16 MB document size limit for MongoDB!"
+            )
+        return value
 
 
 class MongoKafkaDaoPublisherFactory(DaoPublisherFactoryProtocol):

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -265,9 +265,8 @@ async def test_consumer_commit_mode(kafka: KafkaFixture):
 async def test_publishing_with_size_limit(kafka: KafkaFixture, too_big: bool):
     """Test sending messages above or below the configured size limit"""
     # Either leave payload at ~message size or leave ample room for the rest of the event
-    max_message_size = 800000
-    modifier = 0 if too_big else -100000
-    payload = {"test_content": "a" * (max_message_size + modifier)}
+    max_message_size = 800 * 1024  # 800 KiB
+    payload = {"test_content": "a" * int(max_message_size * (1.1 if too_big else 0.9))}
     type_ = "test_type"
     key = "test_key"
     topic = "test_topic"
@@ -291,9 +290,8 @@ async def test_publishing_with_size_limit(kafka: KafkaFixture, too_big: bool):
 )
 async def test_consuming_with_size_limit(kafka: KafkaFixture, too_big: bool):
     """Test receiving messages above or below the configured limit"""
-    max_message_size = 800000
-    modifier = 0 if too_big else -100000
-    payload = {"test_content": "a" * (max_message_size + modifier)}
+    max_message_size = 800 * 1024  # 800 KiB
+    payload = {"test_content": "a" * int(max_message_size * (1.1 if too_big else 0.9))}
     type_ = "test_type"
     key = "test_key"
     topic = "test_topic"
@@ -306,7 +304,8 @@ async def test_consuming_with_size_limit(kafka: KafkaFixture, too_big: bool):
         service_name="test",
         service_instance_id="1",
         kafka_servers=kafka.kafka_servers,
-        kafka_max_message_size=max_message_size * 4,  # publish everything without error
+        kafka_max_message_size=max_message_size
+        * 2,  # publish messages that are too large to consume
     )
 
     async with KafkaEventPublisher.construct(config=producer_config) as publisher:

--- a/tests/integration/test_akafka.py
+++ b/tests/integration/test_akafka.py
@@ -16,6 +16,7 @@
 
 """Testing Apache Kafka based providers."""
 
+from contextlib import nullcontext
 from os import environ
 from pathlib import Path
 from typing import cast
@@ -24,6 +25,7 @@ from unittest.mock import AsyncMock
 import pytest
 from aiokafka import AIOKafkaConsumer
 from aiokafka.admin import AIOKafkaAdminClient
+from aiokafka.errors import MessageSizeTooLargeError
 from aiokafka.structs import TopicPartition
 from pydantic import SecretStr
 
@@ -253,3 +255,71 @@ async def test_consumer_commit_mode(kafka: KafkaFixture):
     assert broker_offsets[partition].offset == consumer_offset
 
     await client.close()
+
+
+@pytest.mark.parametrize(
+    "too_big",
+    [True, False],
+    ids=["TooBig", "AcceptableSize"],
+)
+async def test_publishing_with_size_limit(kafka: KafkaFixture, too_big: bool):
+    """Test sending messages above or below the configured size limit"""
+    # Either leave payload at ~message size or leave ample room for the rest of the event
+    max_message_size = 800000
+    modifier = 0 if too_big else -100000
+    payload = {"test_content": "a" * (max_message_size + modifier)}
+    type_ = "test_type"
+    key = "test_key"
+    topic = "test_topic"
+
+    producer_config = KafkaConfig(
+        service_name="test",
+        service_instance_id="1",
+        kafka_servers=kafka.kafka_servers,
+        kafka_max_message_size=max_message_size,
+    )
+
+    async with KafkaEventPublisher.construct(config=producer_config) as publisher:
+        with pytest.raises(MessageSizeTooLargeError) if too_big else nullcontext():
+            await publisher.publish(payload=payload, type_=type_, key=key, topic=topic)
+
+
+@pytest.mark.parametrize(
+    "too_big",
+    [True, False],
+    ids=["TooBig", "AcceptableSize"],
+)
+async def test_consuming_with_size_limit(kafka: KafkaFixture, too_big: bool):
+    """Test receiving messages above or below the configured limit"""
+    max_message_size = 800000
+    modifier = 0 if too_big else -100000
+    payload = {"test_content": "a" * (max_message_size + modifier)}
+    type_ = "test_type"
+    key = "test_key"
+    topic = "test_topic"
+
+    translator = AsyncMock()
+    translator.topics_of_interest = [topic]
+    translator.types_of_interest = [type_]
+
+    producer_config = KafkaConfig(
+        service_name="test",
+        service_instance_id="1",
+        kafka_servers=kafka.kafka_servers,
+        kafka_max_message_size=max_message_size * 4,  # publish everything without error
+    )
+
+    async with KafkaEventPublisher.construct(config=producer_config) as publisher:
+        await publisher.publish(payload=payload, type_=type_, key=key, topic=topic)
+
+    consumer_config = KafkaConfig(
+        service_name="test",
+        service_instance_id="1",
+        kafka_servers=kafka.kafka_servers,
+        kafka_max_message_size=max_message_size,
+    )
+
+    async with KafkaEventSubscriber.construct(
+        config=consumer_config, translator=translator
+    ) as subscriber:
+        await subscriber.run(forever=False)

--- a/tests/unit/test_mongokafka.py
+++ b/tests/unit/test_mongokafka.py
@@ -1,0 +1,50 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests related to the MongoKafka functionality."""
+
+import logging
+
+from pydantic import SecretStr
+
+from hexkit.providers.mongokafka import MongoKafkaConfig
+
+
+def make_mongokafka_config(kafka_max_message_size: int = 1048576) -> MongoKafkaConfig:
+    """Create a MongoKafkaConfig object with a given kafka_max_message_size."""
+    return MongoKafkaConfig(
+        service_name="test",
+        service_instance_id="1",
+        kafka_servers=["localhost:9092"],
+        db_connection_str=SecretStr("mongodb://localhost:27017"),
+        db_name="test",
+        kafka_max_message_size=kafka_max_message_size,
+    )
+
+
+def test_max_message_size_too_high(caplog):
+    """Test for log message when kafka_max_message_size is over 16 MB."""
+    caplog.clear()
+    config = make_mongokafka_config(16_000_001)
+    record = caplog.records[-1]
+    assert record.levelno == logging.WARNING
+    msg = (
+        "Max message size (16000001) exceeds the 16 MB document size limit for MongoDB!"
+    )
+    assert record.msg % record.args == msg
+    assert config.kafka_max_message_size == 16_000_001
+
+    caplog.clear()
+    config = make_mongokafka_config(16_000_000)
+    assert not caplog.records

--- a/tests/unit/test_mongokafka.py
+++ b/tests/unit/test_mongokafka.py
@@ -36,13 +36,14 @@ def make_mongokafka_config(kafka_max_message_size: int = 1048576) -> MongoKafkaC
 def test_max_message_size_too_high(caplog):
     """Test for log message when kafka_max_message_size is over 16 MiB."""
     caplog.clear()
-    config = make_mongokafka_config(16_777_217)
+    limit = 16 * 1024 * 1024
+    config = make_mongokafka_config(limit + 1)
     record = caplog.records[-1]
     assert record.levelno == logging.WARNING
     msg = "Max message size (16777217) exceeds the 16 MiB document size limit for MongoDB!"
     assert record.msg % record.args == msg
-    assert config.kafka_max_message_size == 16_777_217
+    assert config.kafka_max_message_size == limit + 1
 
     caplog.clear()
-    config = make_mongokafka_config(2**24)
+    config = make_mongokafka_config(limit)
     assert not caplog.records

--- a/tests/unit/test_mongokafka.py
+++ b/tests/unit/test_mongokafka.py
@@ -34,17 +34,15 @@ def make_mongokafka_config(kafka_max_message_size: int = 1048576) -> MongoKafkaC
 
 
 def test_max_message_size_too_high(caplog):
-    """Test for log message when kafka_max_message_size is over 16 MB."""
+    """Test for log message when kafka_max_message_size is over 16 MiB."""
     caplog.clear()
-    config = make_mongokafka_config(16_000_001)
+    config = make_mongokafka_config(16_777_217)
     record = caplog.records[-1]
     assert record.levelno == logging.WARNING
-    msg = (
-        "Max message size (16000001) exceeds the 16 MB document size limit for MongoDB!"
-    )
+    msg = "Max message size (16777217) exceeds the 16 MiB document size limit for MongoDB!"
     assert record.msg % record.args == msg
-    assert config.kafka_max_message_size == 16_000_001
+    assert config.kafka_max_message_size == 16_777_217
 
     caplog.clear()
-    config = make_mongokafka_config(16_000_000)
+    config = make_mongokafka_config(2**24)
     assert not caplog.records


### PR DESCRIPTION
Enables singular config to increase/decrease max bytes of kafka message in publishing and consuming. 

Event pub gets a `max_request_size` param added, and event sub gets `max_partition_fetch_bytes`. MongoKafka config logs a warning if the config field is set above 16MB