### PR TITLE
Improve MongoDB provider tests

### DIFF
--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -188,7 +188,7 @@ class Dao(typing.Protocol[Dto]):
 
         The values in the mapping are used to filter the resources, these are
         assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
-        must be represented as strings. The behavior for non-scalars types depends
+        must be represented as strings. The behavior for non-scalar types depends
         on the specific provider.
 
         Args:

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -144,7 +144,7 @@ class Dao(typing.Protocol[Dto]):
         """
         ...
 
-    async def delete(self, id_: str) -> None:
+    async def delete(self, id_: Union[str, UUID]) -> None:
         """Delete a resource by providing its ID.
 
         Args:

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -156,9 +156,15 @@ class Dao(typing.Protocol[Dto]):
         ...
 
     async def find_one(self, *, mapping: Mapping[str, Any]) -> Dto:
-        """Find the resource that matches the specified mapping. It is expected that
-        at most one resource matches the constraints. An exception is raised if no or
-        multiple hits are found.
+        """Find the resource that matches the specified mapping.
+
+        It is expected that at most one resource matches the constraints.
+        An exception is raised if no or multiple hits are found.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. The behavior for non-scalars types depends
+        on the specific provider.
 
         Args:
             mapping:
@@ -179,6 +185,11 @@ class Dao(typing.Protocol[Dto]):
 
     def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. The behavior for non-scalars types depends
+        on the specific provider.
 
         Args:
             mapping:

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -222,9 +222,15 @@ class MongoDbDao(Generic[Dto]):
         # zero matches)
 
     async def find_one(self, *, mapping: Mapping[str, Any]) -> Dto:
-        """Find the resource that matches the specified mapping. It is expected that
-        at most one resource matches the constraints. An exception is raised if no or
-        multiple hits are found.
+        """Find the resource that matches the specified mapping.
+
+        It is expected that at most one resource matches the constraints.
+        An exception is raised if no or multiple hits are found.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. Dictionaries can be passed as values to
+        specify more complex MongoDB queries.
 
         Args:
             mapping:
@@ -246,6 +252,11 @@ class MongoDbDao(Generic[Dto]):
 
     async def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. Dictionaries can be passed as values to
+        specify more complex MongoDB queries.
 
         Args:
             mapping:

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -201,7 +201,7 @@ class MongoDbDao(Generic[Dto]):
         # (trusting MongoDB that matching on the _id field can only yield one or
         # zero matches)
 
-    async def delete(self, id_: str) -> None:
+    async def delete(self, id_: Union[str, UUID]) -> None:
         """Delete a resource by providing its ID.
 
         Args:
@@ -210,6 +210,9 @@ class MongoDbDao(Generic[Dto]):
         Raises:
             ResourceNotFoundError: when resource with the specified id_ was not found
         """
+        if isinstance(id_, UUID):
+            id_ = str(id_)
+
         result = await self._collection.delete_one({"_id": id_})
 
         if result.deleted_count == 0:

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -294,9 +294,15 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
             await self._publish_delete(id_)
 
     async def find_one(self, *, mapping: Mapping[str, Any]) -> Dto:
-        """Find the resource that matches the specified mapping. It is expected that
-        at most one resource matches the constraints. An exception is raised if no or
-        multiple hits are found.
+        """Find the resource that matches the specified mapping.
+
+        It is expected that at most one resource matches the constraints.
+        An exception is raised if no or multiple hits are found.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. Dictionaries can be passed as values to
+        specify more complex MongoDB queries.
 
         Args:
             mapping:
@@ -318,6 +324,11 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
 
     async def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
+
+        The values in the mapping are used to filter the resources, these are
+        assumed to be standard JSON scalar types. Particularly, UUIDs and datetimes
+        must be represented as strings. Dictionaries can be passed as values to
+        specify more complex MongoDB queries.
 
         Args:
             mapping:

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -263,7 +263,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         if self._autopublish:
             await self._publish_change(dto)
 
-    async def delete(self, id_: str) -> None:
+    async def delete(self, id_: Union[str, UUID]) -> None:
         """Delete a resource by providing its ID.
 
         Args:
@@ -272,6 +272,9 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         Raises:
             ResourceNotFoundError: when resource with the specified id_ was not found
         """
+        if isinstance(id_, UUID):
+            id_ = str(id_)
+
         correlation_id = get_correlation_id()
         document = {
             "_id": id_,

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -43,7 +43,7 @@ pytestmark = pytest.mark.asyncio()
 
 
 class ExampleDto(BaseModel):
-    """Example DTO model without an auto-generated UUID4 ID field."""
+    """Example DTO model with an auto-generated UUID4 ID field."""
 
     model_config = ConfigDict(frozen=True)
 

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -40,35 +40,18 @@ from hexkit.providers.mongodb.testutils import (
 
 pytestmark = pytest.mark.asyncio()
 
-EXAMPLE_ID1 = uuid.UUID("73ab9fd9-edce-4c7a-89fa-f31f7cabbd0b", version=4)
 
-
-class ExampleDtoBase(BaseModel):
-    """Example DTO model with an auto-generated ID."""
+class ExampleDto(BaseModel):
+    """Example DTO with an auto-generated ID."""
 
     model_config = ConfigDict(frozen=True)
-    field_a: str = Field(default="test")
-    field_b: int = Field(default="42")
-    field_c: bool = Field(default=True)
-    field_d: datetime = Field(default_factory=datetime.now)
+    id: UUID4 = UUID4Field(description="The ID of the resource.")
+    field_a: str
+    field_b: int
+    field_c: bool
 
 
-class ExampleDtoWithTypedId(ExampleDtoBase):
-    """Example DTO model with a typed UUID4 ID."""
-
-    id: UUID4 = UUID4Field()
-
-
-class ExampleDtoWithUntypedId(ExampleDtoBase):
-    """Example DTO model with an untyped UUID4 ID."""
-
-    id: str = Field(default_factory=uuid.uuid4)
-
-
-ExampleDto = ExampleDtoWithTypedId
-
-
-async def test_dao_find_all_with_id(mongodb: MongoDbFixture, dto_model):
+async def test_dao_find_all_with_id(mongodb: MongoDbFixture):
     """Test using the id field as part of the mapping in find_all()"""
     dao = await mongodb.dao_factory.get_dao(
         name="example",
@@ -77,7 +60,7 @@ async def test_dao_find_all_with_id(mongodb: MongoDbFixture, dto_model):
     )
 
     # insert an example resource:
-    resource = ExampleDto()
+    resource = ExampleDto(field_a="test1", field_b=27, field_c=True)
     await dao.insert(resource)
 
     str_id = str(resource.id)
@@ -149,7 +132,7 @@ async def test_dao_insert_happy(mongodb: MongoDbFixture):
         id_field="id",
     )
 
-    resource = ExampleDto(id=EXAMPLE_ID1, field_a="test1", field_b=27, field_c=True)
+    resource = ExampleDto(field_a="test1", field_b=27, field_c=True)
     await dao.insert(resource)
 
     # check the newly inserted resource:
@@ -165,13 +148,13 @@ async def test_dao_insert_duplicate_id(mongodb: MongoDbFixture):
         id_field="id",
     )
 
-    resource = ExampleDto(id=EXAMPLE_ID1, field_a="test1", field_b=27, field_c=True)
+    resource = ExampleDto(field_a="test1", field_b=27, field_c=True)
     await dao.insert(resource)
 
     # check error is raised correctly on trying to insert duplicate
     with pytest.raises(
         ResourceAlreadyExistsError,
-        match=f'The resource with the id "{EXAMPLE_ID1}" already exists.',
+        match=f'The resource with the id "{resource.id}" already exists.',
     ):
         await dao.insert(resource)
 
@@ -226,6 +209,22 @@ async def test_dao_update_not_found(mongodb: MongoDbFixture):
         await dao.update(resource)
 
 
+async def test_dao_delete_happy(mongodb: MongoDbFixture):
+    """Tests deleting an existing resource via its ID."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    resource = ExampleDto(field_a="test1", field_b=27, field_c=True)
+    await dao.insert(resource)
+    assert await dao.get_by_id(resource.id) == resource
+    await dao.delete(resource.id)
+    with pytest.raises(ResourceNotFoundError):
+        await dao.get_by_id(resource.id)
+
+
 async def test_dao_delete_not_found(mongodb: MongoDbFixture):
     """Tests deleting a non existing resource via its ID."""
     dao = await mongodb.dao_factory.get_dao(
@@ -248,10 +247,10 @@ async def test_dao_find_invalid_mapping(mongodb: MongoDbFixture):
     mapping = {"non_existing_field": 28}
 
     with pytest.raises(InvalidFindMappingError):
-        _ = await dao.find_one(mapping=mapping)
+        await dao.find_one(mapping=mapping)
 
     with pytest.raises(InvalidFindMappingError):
-        _ = [hit async for hit in dao.find_all(mapping=mapping)]
+        [hit async for hit in dao.find_all(mapping=mapping)]
 
 
 async def test_dao_find_no_hits(mongodb: MongoDbFixture):
@@ -264,7 +263,7 @@ async def test_dao_find_no_hits(mongodb: MongoDbFixture):
     mapping = {"field_c": 28}
 
     with pytest.raises(NoHitsFoundError):
-        _ = await dao.find_one(mapping=mapping)
+        await dao.find_one(mapping=mapping)
 
     resources = [hit async for hit in dao.find_all(mapping=mapping)]
     assert len(resources) == 0
@@ -283,7 +282,7 @@ async def test_dao_find_one_with_multiple_hits(mongodb: MongoDbFixture):
         await dao.insert(ExampleDto(field_a="test1", field_b=27, field_c=True))
 
     with pytest.raises(MultipleHitsFoundError):
-        _ = await dao.find_one(mapping={"field_b": 27})
+        await dao.find_one(mapping={"field_b": 27})
 
 
 async def test_complex_models(mongodb: MongoDbFixture):
@@ -308,9 +307,7 @@ async def test_complex_models(mongodb: MongoDbFixture):
         id="complex_data",
         some_date=datetime(2022, 10, 18, 16, 41, 34, 780735),
         some_path=Path(__file__).resolve(),
-        some_nested_data=ExampleDto(
-            id=EXAMPLE_ID1, field_a="a", field_b=2, field_c=True
-        ),
+        some_nested_data=ExampleDto(field_a="a", field_b=2, field_c=True),
     )
     await dao.insert(resource_to_create)
 
@@ -332,7 +329,6 @@ async def test_duplicate_uuid(mongodb: MongoDbFixture):
             id_ = last_id = uuid.uuid4()
         else:
             last_id = None
-        print("RETURNING", id_)
         return id_
 
     class SmallDto(BaseModel):
@@ -372,3 +368,55 @@ async def test_duplicate_uuid(mongodb: MongoDbFixture):
     assert resource2_observed.id == resource2.id
     assert resource2_observed.id != resource.id
     assert resource2_observed.field == "test2"
+
+
+async def test_dao_crud_happy(mongodb: MongoDbFixture):
+    """Test the happy path of a typical CRUD database interactions in sequence."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    # insert an example resource:
+    resource = ExampleDto(field_a="test1", field_b=27, field_c=True)
+    await dao.insert(resource)
+
+    # read the newly inserted resource:
+    resource_read = await dao.get_by_id(resource.id)
+
+    assert resource_read == resource
+
+    # update the resource:
+    resource_updated = resource.model_copy(update={"field_c": False})
+    await dao.update(resource_updated)
+
+    # read the updated resource again:
+    resource_updated_read = await dao.get_by_id(resource_updated.id)
+
+    assert resource_updated_read == resource_updated
+
+    # insert additional resources:
+    resource2 = ExampleDto(field_a="test2", field_b=27, field_c=True)
+    await dao.insert(resource2)
+    resource3 = ExampleDto(field_a="test3", field_b=27, field_c=False)
+    await dao.upsert(resource3)  # upsert should work here as well
+
+    # perform a search for multiple resources:
+    obtained_hits = {
+        hit async for hit in dao.find_all(mapping={"field_b": 27, "field_c": False})
+    }
+
+    assert obtained_hits == {resource_updated, resource3}
+
+    # find a single resource:
+    obtained_hit = await dao.find_one(mapping={"field_a": "test1"})
+
+    assert obtained_hit == resource_updated
+
+    # delete the resource:
+    await dao.delete(resource.id)
+
+    # confirm that the resource was deleted:
+    with pytest.raises(NoHitsFoundError):
+        obtained_hit = await dao.find_one(mapping={"field_a": "test1"})

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -67,14 +67,11 @@ class CustomIdGenerator:
         return f"id-{self.last_id}"
 
 
-CUSTOM_ID_FACTORY = CustomIdGenerator().id_factory
-
-
 class ExampleDtoWithCustomID(ExampleDto):
     """Example DTO model with a custom string based ID."""
 
     str_id: str = Field(
-        default_factory=CUSTOM_ID_FACTORY,
+        default_factory=CustomIdGenerator().id_factory,
         description="Custom string based ID of the resource.",
     )
 


### PR DESCRIPTION
- Duplicate UUID test shows how to create a resource with different ID without specifying all fields again
- Deletion by UUID is now working and tested
- Made tests a bit simpler by using default values
- Since we now only test with UUIDs, added test for str based IDs with custom field name and format
- Mention caveats for find_one and find_all