### PR TITLE
Use Secret[MongoDsn] for db connection string (GSI-952)

### DIFF
--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -32,7 +32,7 @@ from uuid import UUID
 
 from motor.core import AgnosticCollection
 from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import Field, SecretStr
+from pydantic import Field, MongoDsn, Secret
 from pydantic_settings import BaseSettings
 from pymongo.errors import DuplicateKeyError
 
@@ -366,7 +366,7 @@ class MongoDbConfig(BaseSettings):
     Inherit your config class from this class if your application uses MongoDB.
     """
 
-    db_connection_str: SecretStr = Field(
+    mongo_dsn: Secret[MongoDsn] = Field(
         ...,
         examples=["mongodb://localhost:27017"],
         description=(
@@ -399,7 +399,7 @@ class MongoDbDaoFactory(DaoFactoryProtocol):
 
         # get a database-specific client:
         self._client: AsyncIOMotorClient = AsyncIOMotorClient(
-            self._config.db_connection_str.get_secret_value()
+            str(self._config.mongo_dsn.get_secret_value())
         )
         self._db = self._client[self._config.db_name]
 

--- a/src/hexkit/providers/mongodb/testutils.py
+++ b/src/hexkit/providers/mongodb/testutils.py
@@ -24,7 +24,6 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 import pytest
-from pydantic import SecretStr
 from pymongo import MongoClient
 from pymongo.errors import ExecutionTimeout, OperationFailure
 from testcontainers.mongodb import MongoDbContainer
@@ -100,9 +99,9 @@ class MongoDbContainerFixture(MongoDbContainer):
 def _mongodb_container_fixture() -> Generator[MongoDbContainerFixture, None, None]:
     """Fixture function for getting a running MongoDB test container."""
     with MongoDbContainerFixture(image=MONGODB_IMAGE) as mongodb_container:
-        db_connection_str = mongodb_container.get_connection_url()
         mongodb_config = MongoDbConfig(
-            db_connection_str=SecretStr(db_connection_str), db_name="test"
+            mongo_dsn=mongodb_container.get_connection_url(),
+            db_name="test",
         )
         mongodb_container.mongodb_config = mongodb_config
         yield mongodb_container

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -476,7 +476,7 @@ class MongoKafkaDaoPublisherFactory(DaoPublisherFactoryProtocol):
 
         # get a database-specific client:
         self._client: AsyncIOMotorClient = AsyncIOMotorClient(
-            self._config.db_connection_str.get_secret_value()
+            str(self._config.mongo_dsn.get_secret_value())
         )
         self._db = self._client[self._config.db_name]
 

--- a/tests/unit/test_mongokafka.py
+++ b/tests/unit/test_mongokafka.py
@@ -16,8 +16,6 @@
 
 import logging
 
-from pydantic import SecretStr
-
 from hexkit.providers.mongokafka import MongoKafkaConfig
 
 
@@ -27,7 +25,7 @@ def make_mongokafka_config(kafka_max_message_size: int = 1048576) -> MongoKafkaC
         service_name="test",
         service_instance_id="1",
         kafka_servers=["localhost:9092"],
-        db_connection_str=SecretStr("mongodb://localhost:27017"),
+        mongo_dsn="mongodb://localhost:27017",  # type: ignore
         db_name="test",
         kafka_max_message_size=kafka_max_message_size,
     )


### PR DESCRIPTION
`db_connection_str: SecretStr` is now `mongo_dsn: Secret[MongoDsn]`. Mypy will complain about string arguments to the parameter, but those can be ignored.

I determined that `list[KafkaDsn]` was not a good fit for the `kafka_servers` config option because that type expects the scheme/full URL, e.g. `"kafka://localhost:9092"`. AIOKafka expects a list of host:ports for the bootstrap servers, and fails if you supply the full URL. Validation for 'host[:port]' is not supported by an existing Pydantic type, and I'm not convinced there's sufficient benefit in building a validator. The most likely violations are probably typos of the variety that can't be caught by pattern matching.