### PR TITLE
Configurable MongoDB Timeout (GSI-987)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -52,7 +52,8 @@
 				"visualstudioexptteam.vscodeintellicode",
 				"ymotongpoo.licenser",
 				"charliermarsh.ruff",
-				"ms-python.mypy-type-checker"
+				"ms-python.mypy-type-checker",
+				"-ms-python.autopep8"
 			]
 		}
 	},

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -47,7 +47,11 @@ __all__ = [
 Dto = TypeVar("Dto", bound=BaseModel)
 
 
-class ResourceNotFoundError(RuntimeError):
+class DaoError(RuntimeError):
+    """Base for all errors related to DAO operations."""
+
+
+class ResourceNotFoundError(DaoError):
     """Raised when a requested resource did not exist."""
 
     def __init__(self, *, id_: ID):
@@ -55,7 +59,7 @@ class ResourceNotFoundError(RuntimeError):
         super().__init__(message)
 
 
-class ResourceAlreadyExistsError(RuntimeError):
+class ResourceAlreadyExistsError(DaoError):
     """Raised when a resource did unexpectedly exist."""
 
     def __init__(self, *, id_: ID):
@@ -63,7 +67,7 @@ class ResourceAlreadyExistsError(RuntimeError):
         super().__init__(message)
 
 
-class FindError(RuntimeError):
+class FindError(DaoError):
     """Base for all error related to DAO find operations."""
 
 
@@ -97,11 +101,11 @@ class NoHitsFoundError(FindError):
         super().__init__(message)
 
 
-class DbTimeoutError(RuntimeError):
+class DbTimeoutError(DaoError):
     """Raised when a database operation timed out."""
 
-    def __init__(self, reason: str):
-        message = f"The database operation timed out: {reason}"
+    def __init__(self, details: str):
+        message = f"The database operation timed out: {details}"
         super().__init__(message)
 
 

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -97,6 +97,14 @@ class NoHitsFoundError(FindError):
         super().__init__(message)
 
 
+class DbTimeoutError(RuntimeError):
+    """Raised when a database operation timed out."""
+
+    def __init__(self, reason: str):
+        message = f"The database operation timed out: {reason}"
+        super().__init__(message)
+
+
 # provide standardized default factory for UUID4 fields
 UUID4Field = partial(Field, default_factory=uuid4)
 

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -27,7 +27,7 @@ from contextlib import AbstractAsyncContextManager, contextmanager
 from datetime import date, datetime
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Generic, Optional
+from typing import Any, Callable, Generic, Optional, Union
 from uuid import UUID
 
 from motor.core import AgnosticCollection
@@ -404,7 +404,7 @@ class MongoDbConfig(BaseSettings):
         examples=["my-database"],
         description="Name of the database located on the MongoDB server.",
     )
-    mongo_timeout: PositiveInt | None = Field(
+    mongo_timeout: Union[PositiveInt, None] = Field(
         default=None,
         examples=[300, 600, None],
         description=(

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -408,7 +408,7 @@ class MongoDbConfig(BaseSettings):
         default=None,
         examples=[300, 600, None],
         description=(
-            "Timeout in seconds for API calls to MongoDB. The timeout applies all steps"
+            "Timeout in seconds for API calls to MongoDB. The timeout applies to all steps"
             + " needed to complete the operation, including server selection, connection"
             + " checkout, serialization, and server-side execution. When the timeout"
             + " expires, PyMongo raises a timeout exception. If set to None, the"
@@ -440,7 +440,7 @@ class MongoDbDaoFactory(DaoFactoryProtocol):
         # get a database-specific client:
         self._client: AsyncIOMotorClient = AsyncIOMotorClient(
             str(self._config.mongo_dsn.get_secret_value()),
-            timeoutms=timeout_ms,
+            timeoutMS=timeout_ms,
         )
         self._db = self._client[self._config.db_name]
 

--- a/src/hexkit/providers/mongodb/provider.py
+++ b/src/hexkit/providers/mongodb/provider.py
@@ -32,7 +32,7 @@ from uuid import UUID
 
 from motor.core import AgnosticCollection
 from motor.motor_asyncio import AsyncIOMotorClient
-from pydantic import Field, MongoDsn, Secret
+from pydantic import Field, MongoDsn, PositiveInt, Secret
 from pydantic_settings import BaseSettings
 from pymongo.errors import DuplicateKeyError
 
@@ -379,6 +379,17 @@ class MongoDbConfig(BaseSettings):
         ...,
         examples=["my-database"],
         description="Name of the database located on the MongoDB server.",
+    )
+    mongo_timeout: PositiveInt | None = Field(
+        default=None,
+        examples=[300, 600, None],
+        description=(
+            "Timeout in seconds for API calls to MongoDB. The timeout applies all steps"
+            + " needed to complete the operation, including server selection, connection"
+            + " checkout, serialization, and server-side execution. When the timeout"
+            + " expires, PyMongo raises a timeout exception. If set to None, the"
+            + " operation will not time out (default MongoDB behavior)."
+        ),
     )
 
 

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -44,6 +44,7 @@ from hexkit.providers.mongodb.provider import (
     MongoDbDao,
     get_single_hit,
     replace_id_field_in_find_mapping,
+    translate_timeout_error,
     validate_find_mapping,
     value_to_document,
 )
@@ -120,7 +121,10 @@ def get_change_publish_func(
             )
 
         document = dto_to_document(dto, id_field=id_field, published=True)
-        await collection.replace_one({"_id": document["_id"]}, document, upsert=True)
+        with translate_timeout_error():
+            await collection.replace_one(
+                {"_id": document["_id"]}, document, upsert=True
+            )
 
     return publish_change
 
@@ -152,7 +156,8 @@ def get_delete_publish_func(
                 "correlation_id": correlation_id,
             },
         }
-        await collection.replace_one({"_id": document["_id"]}, document)
+        with translate_timeout_error():
+            await collection.replace_one({"_id": document["_id"]}, document)
 
     return publish_deletion
 
@@ -255,9 +260,10 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         correlation_id = get_correlation_id()
         document = self._dao._dto_to_document(dto)
         document.setdefault("__metadata__", {})["correlation_id"] = correlation_id
-        result = await self._collection.replace_one(
-            {"_id": document["_id"], "__metadata__.deleted": False}, document
-        )
+        with translate_timeout_error():
+            result = await self._collection.replace_one(
+                {"_id": document["_id"], "__metadata__.deleted": False}, document
+            )
         if result.matched_count == 0:
             raise ResourceNotFoundError(id_=document["_id"])
 
@@ -284,9 +290,10 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                 "correlation_id": correlation_id,
             },
         }
-        result = await self._collection.replace_one(
-            {"_id": document["_id"], "__metadata__.deleted": False}, document
-        )
+        with translate_timeout_error():
+            result = await self._collection.replace_one(
+                {"_id": document["_id"], "__metadata__.deleted": False}, document
+            )
         if result.matched_count == 0:
             raise ResourceNotFoundError(id_=id_)
 
@@ -342,14 +349,15 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
-        cursor = self._collection.find(filter=self._convert_filter_values(mapping))
+        with translate_timeout_error():
+            cursor = self._collection.find(filter=self._convert_filter_values(mapping))
 
-        async for document in cursor:
-            if document.get("__metadata__", {}).get("deleted", False):
-                continue
-            yield document_to_dto(
-                document, id_field=self._id_field, dto_model=self._dto_model
-            )
+            async for document in cursor:
+                if document.get("__metadata__", {}).get("deleted", False):
+                    continue
+                yield document_to_dto(
+                    document, id_field=self._id_field, dto_model=self._dto_model
+                )
 
     def _convert_filter_values(self, value: Any) -> Any:
         """Convert filter values with non-standard types.
@@ -413,7 +421,8 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
 
     async def publish_pending(self) -> None:
         """Publishes all non-published changes."""
-        cursor = self._collection.find(filter={"__metadata__.published": False})
+        with translate_timeout_error():
+            cursor = self._collection.find(filter={"__metadata__.published": False})
 
         async for document in cursor:
             await self.publish_document(document)
@@ -422,7 +431,8 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         """Republishes the state of all resources independent of whether they have
         already been published or not.
         """
-        cursor = self._collection.find()
+        with translate_timeout_error():
+            cursor = self._collection.find()
 
         async for document in cursor:
             await self.publish_document(document)
@@ -473,11 +483,14 @@ class MongoKafkaDaoPublisherFactory(DaoPublisherFactoryProtocol):
     ):
         """Please do not call directly! Should be called by the `construct` method."""
         self._config = config
+        timeout_ms = int(config.mongo_timeout * 1000) if config.mongo_timeout else None
 
         # get a database-specific client:
         self._client: AsyncIOMotorClient = AsyncIOMotorClient(
-            str(self._config.mongo_dsn.get_secret_value())
+            str(self._config.mongo_dsn.get_secret_value()),
+            timeoutms=timeout_ms,
         )
+
         self._db = self._client[self._config.db_name]
 
         self._event_publisher = event_publisher

--- a/src/hexkit/providers/mongokafka/provider.py
+++ b/src/hexkit/providers/mongokafka/provider.py
@@ -488,7 +488,7 @@ class MongoKafkaDaoPublisherFactory(DaoPublisherFactoryProtocol):
         # get a database-specific client:
         self._client: AsyncIOMotorClient = AsyncIOMotorClient(
             str(self._config.mongo_dsn.get_secret_value()),
-            timeoutms=timeout_ms,
+            timeoutMS=timeout_ms,
         )
 
         self._db = self._client[self._config.db_name]

--- a/tests/unit/test_mongokafka.py
+++ b/tests/unit/test_mongokafka.py
@@ -27,7 +27,10 @@ from hexkit.providers.mongokafka.provider import MongoKafkaDaoPublisherFactory
 
 
 def make_mongokafka_config(kafka_max_message_size: int = 1048576) -> MongoKafkaConfig:
-    """Create a MongoKafkaConfig object with a given kafka_max_message_size."""
+    """Create a MongoKafkaConfig object with a given kafka_max_message_size.
+
+    The value for `mongo_dsn` should *not* point to a running MongoDB instance.
+    """
     return MongoKafkaConfig(
         service_name="test",
         service_instance_id="1",
@@ -57,7 +60,7 @@ def test_max_message_size_too_high(caplog):
 
 @pytest.mark.asyncio
 async def test_mongokafka_timeout():
-    """Test that the timeout is set correctly."""
+    """Test that the timeout is set correctly by using a Mongo DSN that doesn't exist."""
     config = make_mongokafka_config()
     dao_factory = MongoKafkaDaoPublisherFactory(
         config=config, event_publisher=AsyncMock()


### PR DESCRIPTION
This adds `mongo_timeout` to the `MongoDbConfig` class. The value is in seconds. The default is `None`, which will preserve the MongoDb default behavior. I chose this opt-in approach because the appropriate value varies by use-case and I don't know that we have a sense for what it should be, if set at all.

**More info:**  
The timeout config value is converted from seconds to milliseconds when instantiating the -DaoFactory and supplied to the client.  
The timeout is then applied to all subsequent API requests through that client (effectively the DAO). 

When a timeout occurs in Pymongo, it will result in one of several errors that subclass `PyMongoError`. PyMongoError is also the base class for other error types, and the timeout-caused errors can be identified by `error.timeout`, a property that defaults to `False`.  
DB operations in the MongoDb and MongoKafka providers are wrapped with an error translation function that reraises the various flavors of timeout error as `DbTimeoutError`.

**Testing:**  
The tests added are simple. There is a test for the translation wrapper itself, then a test (added for both Mongo/MongoKafka) that adds the shortest configurable timeout and attempts each of the DAO functions to ensure the timeouts are caught. The purpose of the test is not to test translation but to make sure that error handling (via the wrapper) is applied everywhere it should be.