### PR TITLE
Include exception info in DLQ event headers (GSI-1119)

### DIFF
--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -45,7 +45,7 @@ from hexkit.providers.akafka.provider.utils import (
 
 ORIGINAL_TOPIC_FIELD = "original_topic"
 EXC_CLASS_FIELD = "exc_class"
-EXC_INFO_FIELD = "exc_info"
+EXC_MSG_FIELD = "exc_msg"
 
 
 class ConsumerEvent(Protocol):
@@ -302,7 +302,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             headers={
                 ORIGINAL_TOPIC_FIELD: event.topic,
                 EXC_CLASS_FIELD: exc.__class__.__name__,
-                EXC_INFO_FIELD: str(exc),
+                EXC_MSG_FIELD: str(exc),
             },
         )
         logging.info("Published event to DLQ topic '%s'", self._dlq_topic)
@@ -516,7 +516,7 @@ def validate_dlq_headers(event: ConsumerEvent) -> None:
         "correlation_id",
         ORIGINAL_TOPIC_FIELD,
         EXC_CLASS_FIELD,
-        EXC_INFO_FIELD,
+        EXC_MSG_FIELD,
     ]
     invalid_headers = [key for key in expected_headers if not headers.get(key)]
     if invalid_headers:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -44,6 +44,8 @@ from hexkit.providers.akafka.provider.utils import (
 )
 
 ORIGINAL_TOPIC_FIELD = "original_topic"
+EXC_CLASS_FIELD = "exc_class"
+EXC_INFO_FIELD = "exc_info"
 
 
 class ConsumerEvent(Protocol):
@@ -281,15 +283,27 @@ class KafkaEventSubscriber(InboundProviderBase):
         self._enable_dlq = config.kafka_enable_dlq
         self._retry_backoff = config.kafka_retry_backoff
 
-    async def _publish_to_dlq(self, *, event: ExtractedEventInfo):
-        """Publish the event to the DLQ topic."""
+    async def _publish_to_dlq(self, *, event: ExtractedEventInfo, exc: Exception):
+        """Publish the event to the DLQ topic.
+
+        The exception instance is included in the headers, but is split into the class
+        name and the string representation of the exception.
+
+        Args
+        - `event`: The event to publish to the DLQ.
+        - `exc`: The exception that caused the event to be published to the DLQ.
+        """
         logging.debug("About to publish an event to DLQ topic '%s'", self._dlq_topic)
         await self._dlq_publisher.publish(  # type: ignore
             payload=event.payload,
             type_=event.type_,
             topic=self._dlq_topic,
             key=event.key,
-            headers={ORIGINAL_TOPIC_FIELD: event.topic},
+            headers={
+                ORIGINAL_TOPIC_FIELD: event.topic,
+                EXC_CLASS_FIELD: exc.__class__.__name__,
+                EXC_INFO_FIELD: str(exc),
+            },
         )
         logging.info("Published event to DLQ topic '%s'", self._dlq_topic)
 
@@ -367,7 +381,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             if not self._max_retries:
                 if not self._enable_dlq:
                     raise  # re-raise Exception
-                await self._publish_to_dlq(event=event)
+                await self._publish_to_dlq(event=event, exc=underlying_error)
                 return
 
             # Don't raise RetriesExhaustedError unless retries are actually attempted
@@ -380,7 +394,7 @@ class KafkaEventSubscriber(InboundProviderBase):
                 logging.warning(retry_error)
                 if not self._enable_dlq:
                     raise retry_error from underlying_error
-                await self._publish_to_dlq(event=event)
+                await self._publish_to_dlq(event=event, exc=underlying_error)
 
     def _extract_info(self, event: ConsumerEvent) -> ExtractedEventInfo:
         """Validate the event, returning the extracted info."""
@@ -442,6 +456,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             async with set_correlation_id(correlation_id):
                 await self._handle_consumption(event=event_info)
         except Exception:
+            # Errors only bubble up here if the DLQ isn't used
             logging.critical(
                 "An error occurred while processing event of type '%s': %s. It was NOT"
                 " placed in the DLQ topic (%s)",
@@ -496,7 +511,13 @@ def validate_dlq_headers(event: ConsumerEvent) -> None:
     - `DLQValidationError`: If any headers are determined to be invalid.
     """
     headers = headers_as_dict(event)
-    expected_headers = ["type", "correlation_id", ORIGINAL_TOPIC_FIELD]
+    expected_headers = [
+        "type",
+        "correlation_id",
+        ORIGINAL_TOPIC_FIELD,
+        EXC_CLASS_FIELD,
+        EXC_INFO_FIELD,
+    ]
     invalid_headers = [key for key in expected_headers if not headers.get(key)]
     if invalid_headers:
         error_msg = f"Missing or empty headers: {', '.join(invalid_headers)}"

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -31,7 +31,7 @@ from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.akafka.provider.daosub import KafkaOutboxSubscriber
 from hexkit.providers.akafka.provider.eventsub import (
     EXC_CLASS_FIELD,
-    EXC_INFO_FIELD,
+    EXC_MSG_FIELD,
     ORIGINAL_TOPIC_FIELD,
     ConsumerEvent,
     DLQProcessingError,
@@ -375,7 +375,7 @@ async def test_retries_exhausted(
         headers={
             ORIGINAL_TOPIC_FIELD: "test-topic",
             EXC_CLASS_FIELD: "RuntimeError",
-            EXC_INFO_FIELD: "Destined to fail.",
+            EXC_MSG_FIELD: "Destined to fail.",
         },
     )
 
@@ -413,7 +413,7 @@ async def test_send_to_retry(kafka: KafkaFixture, caplog_debug):
         headers={
             ORIGINAL_TOPIC_FIELD: "test-topic",
             EXC_CLASS_FIELD: "RuntimeError",
-            EXC_INFO_FIELD: "Destined to fail.",
+            EXC_MSG_FIELD: "Destined to fail.",
         },
     )
 

--- a/tests/unit/test_dlqsub.py
+++ b/tests/unit/test_dlqsub.py
@@ -30,6 +30,8 @@ from hexkit.protocols.eventsub import EventSubscriberProtocol
 from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.akafka.provider.daosub import KafkaOutboxSubscriber
 from hexkit.providers.akafka.provider.eventsub import (
+    EXC_CLASS_FIELD,
+    EXC_INFO_FIELD,
     ORIGINAL_TOPIC_FIELD,
     ConsumerEvent,
     DLQProcessingError,
@@ -370,7 +372,11 @@ async def test_retries_exhausted(
         topic=config.kafka_dlq_topic,
         key=TEST_EVENT.key,
         payload=TEST_EVENT.payload,
-        headers={ORIGINAL_TOPIC_FIELD: "test-topic"},
+        headers={
+            ORIGINAL_TOPIC_FIELD: "test-topic",
+            EXC_CLASS_FIELD: "RuntimeError",
+            EXC_INFO_FIELD: "Destined to fail.",
+        },
     )
 
     # Verify that the event was sent to the DLQ topic just once and that it has
@@ -404,7 +410,11 @@ async def test_send_to_retry(kafka: KafkaFixture, caplog_debug):
         type_="test_type",
         topic=config.kafka_dlq_topic,
         key="123456",
-        headers={ORIGINAL_TOPIC_FIELD: "test-topic"},
+        headers={
+            ORIGINAL_TOPIC_FIELD: "test-topic",
+            EXC_CLASS_FIELD: "RuntimeError",
+            EXC_INFO_FIELD: "Destined to fail.",
+        },
     )
 
     await kafka.publisher.publish(**vars(event_to_put_in_dlq))
@@ -425,6 +435,9 @@ async def test_send_to_retry(kafka: KafkaFixture, caplog_debug):
 
     # Verify that the event was sent to the RETRY topic
     event_to_put_in_dlq.topic = config.kafka_retry_topic
+
+    # The exc_... headers are not supposed to be in the retry event
+    event_to_put_in_dlq.headers = {ORIGINAL_TOPIC_FIELD: "test-topic"}
     assert dummy_publisher.published == [event_to_put_in_dlq]
 
 


### PR DESCRIPTION
DLQ events should automatically contain the underlying exception information. This does not bump the version number because it should really be part of the 4.0 release.

This PR modifies the process so that `KafkaEventSubscriber._publish_to_dlq()` now requires an exception instance.
The exception instance is translated into 2 headers for the event published to the DLQ:
- `exc_class`: the name of the error's class, e.g. `RuntimeError`, `ValueError`, etc., which could be used by the DLQ service's processing logic to triage events.
- `exc_info`: the exception text, useful for developers to diagnose problems. Further traceback can be found in the logs using Grafana (if available)