### PR TITLE
Add Kafka DLQ Subscriber Preview functionality (GSI-1127)

### DIFF
--- a/src/hexkit/providers/akafka/config.py
+++ b/src/hexkit/providers/akafka/config.py
@@ -126,6 +126,12 @@ class KafkaConfig(BaseSettings):
         title="Kafka Retry Backoff",
         examples=[0, 1, 2, 3, 5],
     )
+    kafka_preview_limit: PositiveInt = Field(
+        default=1,
+        description="The maximum number of events to preview from the DLQ topic.",
+        title="Kafka DLQ Preview",
+        examples=[1, 3, 5],
+    )
 
     @model_validator(mode="after")
     def validate_retry_topic(self):

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -543,7 +543,7 @@ async def process_dlq_event(event: ConsumerEvent) -> Optional[ExtractedEventInfo
     return ExtractedEventInfo(event)
 
 
-class KafkaDLQSubscriber(InboundProviderBase):
+class KafkaDLQSubscriber:
     """A kafka event subscriber that subscribes to the configured DLQ topic and either
     discards each event or publishes it to the retry topic as instructed.
     Further processing before requeuing is provided by a callable adhering to the

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -79,7 +79,7 @@ class ExtractedEventInfo:
         self.key = kwargs.get("key", event.key if event else "")
         self.headers = kwargs.get("headers", headers_as_dict(event) if event else {})
         self.headers = cast(dict, self.headers)
-        self.type_ = kwargs.get("type_", self.headers.get("type", ""))
+        self.type_ = kwargs.get("type_", self.headers.pop("type", ""))
 
     @property
     def encoded_headers(self) -> list[tuple[str, bytes]]:


### PR DESCRIPTION
### `KafkaConfig`
- Adds one config option, `kafka_preview_limit`, which is 1 by default.

### `ExtractedEventInfo`
- The `type_` assignment used to fall back to the header value, but didn't remove it. The result is that the "type" would be found both in the top-level `type_` variable as well as in `headers["type"]`. Now, the value is popped.

### `KafkaDLQSubscriber`
- Added a `preview` method that return at most N=`kafka_preview_limit` events from the configured DLQ topic.
- Moved logic for `run(ignore=True)` into a new method, `ignore()`.
- Renamed `run(ignore=False)` to `process()`.
- Removed the subclassing of `InboundProviderBase` because this is actually a specialized class that has little overlap with the normal subscriber provider class.
- The `__init__` function now takes the whole config instance and internally breaks out the values it needs (topics/preview limit)
