### PR TITLE
Backport S3 copy operation fix

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "3.8.0"
+version = "3.8.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "3.8.0"
+version = "3.8.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/providers/s3/provider.py
+++ b/src/hexkit/providers/s3/provider.py
@@ -22,6 +22,7 @@ Utilities for testing are located in `./testutils.py`.
 # ruff: noqa: PLR0913
 
 import asyncio
+import logging
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -848,6 +849,17 @@ class S3ObjectStorage(ObjectStorageProtocol):
         await self._assert_object_not_exists(
             bucket_id=dest_bucket_id, object_id=dest_object_id
         )
+
+        underway_operations = await self._list_multipart_upload_for_object(
+            bucket_id=dest_bucket_id, object_id=dest_object_id
+        )
+        if len(underway_operations) > 0:
+            logging.info(
+                "Copy operation already exists for dest object id '%s' in dest bucket '%s'.",
+                dest_object_id,
+                dest_bucket_id,
+            )
+            return
 
         part_size = calc_part_size(file_size=file_size)
 

--- a/src/hexkit/providers/s3/provider.py
+++ b/src/hexkit/providers/s3/provider.py
@@ -855,7 +855,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         )
         if len(underway_operations) > 0:
             logging.info(
-                "Copy operation already exists for dest object id '%s' in dest bucket '%s'.",
+                "Upload or copy operation already exists for dest object id '%s' in dest bucket '%s'.",
                 dest_object_id,
                 dest_bucket_id,
             )

--- a/src/hexkit/providers/s3/provider.py
+++ b/src/hexkit/providers/s3/provider.py
@@ -855,7 +855,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         )
         if len(underway_operations) > 0:
             logging.info(
-                "Upload or copy operation already exists for dest object id '%s' in dest bucket '%s'.",
+                "Upload or copy operation already exists for object id '%s' in bucket '%s'.",
                 dest_object_id,
                 dest_bucket_id,
             )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -622,6 +622,6 @@ async def test_concurrent_copy_requests(s3: S3Fixture, caplog):
         mock.assert_not_called()
         assert len(caplog.records) == 1
         assert caplog.records[0].getMessage() == (
-            f"Upload or copy operation already exists for dest object id '{dest_object_id}'"
-            + f" in dest bucket '{dest_bucket_id}'."
+            f"Upload or copy operation already exists for object id '{dest_object_id}'"
+            + f" in bucket '{dest_bucket_id}'."
         )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -17,6 +17,7 @@
 
 from contextlib import AbstractContextManager, nullcontext
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 
@@ -585,3 +586,42 @@ async def test_handling_multiple_subsequent_uploads(abort_first: bool, s3: S3Fix
     await s3.storage.complete_multipart_upload(
         upload_id=upload2_id, bucket_id=bucket_id, object_id=object_id
     )
+
+
+async def test_concurrent_copy_requests(s3: S3Fixture, caplog):
+    """Ensure subsequent copy requests for a given file don't initiate new S3 copy
+    operations if one is already underway.
+    """
+    source_bucket_id = "source-bucket"
+    source_object_id = "source-object"
+
+    # Upload a file to the source bucket
+    with temp_file_object(source_bucket_id, source_object_id) as file:
+        await s3.populate_file_objects([file])
+
+        # Create an upload that mimics an ongoing copy operation
+        _, dest_bucket_id, dest_object_id = await s3.get_initialized_upload()
+
+        # Mock the boto client's copy method so we can check if it was called
+        mock = Mock()
+        s3.storage._client.copy = mock
+
+        # Clear caplog buffer and enable capturing INFO-level logs
+        caplog.clear()
+        caplog.set_level("INFO")
+
+        # Attempt to copy the object temp file to the destination bucket/object
+        await s3.storage.copy_object(
+            source_bucket_id=source_bucket_id,
+            source_object_id=source_object_id,
+            dest_bucket_id=dest_bucket_id,
+            dest_object_id=dest_object_id,
+        )
+
+        # Check that the client copy method was not called and that a message was logged
+        mock.assert_not_called()
+        assert len(caplog.records) == 1
+        assert caplog.records[0].getMessage() == (
+            f"Copy operation already exists for dest object id '{dest_object_id}'"
+            + f" in dest bucket '{dest_bucket_id}'."
+        )

--- a/tests/integration/test_s3.py
+++ b/tests/integration/test_s3.py
@@ -622,6 +622,6 @@ async def test_concurrent_copy_requests(s3: S3Fixture, caplog):
         mock.assert_not_called()
         assert len(caplog.records) == 1
         assert caplog.records[0].getMessage() == (
-            f"Copy operation already exists for dest object id '{dest_object_id}'"
+            f"Upload or copy operation already exists for dest object id '{dest_object_id}'"
             + f" in dest bucket '{dest_bucket_id}'."
         )


### PR DESCRIPTION
Bumps version to `3.8.1`

You might notice the use of caplog is slightly different in the test, you can ignore that. There's a test util in v4 called `assert_logged` that doesn't exist in v3.