### PR TITLE
Update how DLQ subscriber is instantiated (GSI-1274)

### DIFF
--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -566,10 +566,8 @@ class KafkaDLQSubscriber:
     DLQEventProcessor definition.
     """
 
-    @classmethod
-    @asynccontextmanager
-    async def construct(  # noqa: PLR0913
-        cls,
+    def __init__(  # noqa: PLR0913
+        self,
         *,
         config: KafkaConfig,
         dlq_topic: str,
@@ -628,48 +626,6 @@ class KafkaDLQSubscriber:
             max_partition_fetch_bytes=config.kafka_max_message_size,
         )
 
-        await consumer.start()
-        try:
-            yield cls(
-                dlq_topic=dlq_topic,
-                dlq_publisher=dlq_publisher,
-                consumer=consumer,
-                process_dlq_event=process_dlq_event,
-                timeout_ms=timeout_ms,
-            )
-        finally:
-            await consumer.stop()
-
-    def __init__(
-        self,
-        *,
-        dlq_topic: str,
-        dlq_publisher: EventPublisherProtocol,
-        consumer: KafkaConsumerCompatible,
-        process_dlq_event: DLQEventProcessor,
-        timeout_ms: int,
-    ):
-        """Please do not call directly! Should be called by the `construct` method.
-
-        Args:
-        - `dlq_topic`:
-            The name of the DLQ topic to subscribe to. Has the format
-            "{original_topic}.{service_name}-dlq".
-        - `dlq_publisher`:
-            A running instance of a publishing provider that implements the
-            EventPublisherProtocol, such as KafkaEventPublisher.
-        - `consumer`:
-            hands over a started AIOKafkaConsumer.
-        - `process_dlq_event`:
-            An async callable adhering to the DLQEventProcessor definition that provides
-            validation and processing for events from the DLQ. It should return _either_
-            the event to publish to the retry topic (which may be altered) or `None` to
-            discard the event. The `KafkaDLQSubscriber` will log and interpret
-            `DLQValidationError` as a signal to discard/ignore the event, and all other
-            errors will be re-raised as a `DLQProcessingError`.
-        - `timeout_ms`:
-            The maximum time in milliseconds to spend reading from the DLQ topic.
-        """
         self._consumer = consumer
         self._publisher = dlq_publisher
         self._dlq_topic = dlq_topic
@@ -682,6 +638,23 @@ class KafkaDLQSubscriber:
         service_name = service_name_from_dlq_topic(dlq_topic)
         self._retry_topic = service_name + "-retry"
         self._process_dlq_event = process_dlq_event
+
+    async def __aenter__(self) -> "KafkaDLQSubscriber":
+        """Start consuming events from the DLQ topic."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        """Stop consuming events from the DLQ topic."""
+        await self.stop()
+
+    async def start(self) -> None:
+        """Start consuming events from the DLQ topic."""
+        await self._consumer.start()
+
+    async def stop(self) -> None:
+        """Stop consuming events from the DLQ topic."""
+        await self._consumer.stop()
 
     async def _publish_to_retry(self, *, event: ExtractedEventInfo) -> None:
         """Publish the event to the retry topic."""
@@ -722,9 +695,9 @@ class KafkaDLQSubscriber:
         # the wrong data to resolve the DLQ event (e.g. copy/paste error)
         if dlq_event.headers["correlation_id"] != override.headers["correlation_id"]:
             msg = (
-                "Cannot manually resolve DLQ event due to correlation ID mismatch.\n"
-                + f"User-supplied event ID: {override.headers['correlation_id']}\n"
-                + f"DLQ event ID: {dlq_event.headers['correlation_id']}"
+                "Cannot manually resolve DLQ event due to correlation ID mismatch."
+                + f"\nExpected {dlq_event.headers['correlation_id']} but user"
+                + f" gave {override.headers['correlation_id']}"
             )
             raise RuntimeError(msg)
 

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -696,8 +696,8 @@ class KafkaDLQSubscriber:
         if dlq_event.headers["correlation_id"] != override.headers["correlation_id"]:
             msg = (
                 "Cannot manually resolve DLQ event due to correlation ID mismatch."
-                + f"\nExpected {dlq_event.headers['correlation_id']} but user"
-                + f" gave {override.headers['correlation_id']}"
+                + f"\nExpected {dlq_event.headers['correlation_id']} but"
+                + f" got {override.headers['correlation_id']}"
             )
             raise RuntimeError(msg)
 

--- a/tests/integration/test_dlqsub.py
+++ b/tests/integration/test_dlqsub.py
@@ -844,7 +844,7 @@ async def test_process_override_different_cid(kafka: KafkaFixture):
     # Create the DLQ subscriber and manually resolve the DLQ event, expecting an error
     msg = (
         "Cannot manually resolve DLQ event due to correlation ID mismatch."
-        + f"\nExpected {TEST_CORRELATION_ID} but user gave {headers['correlation_id']}"
+        + f"\nExpected {TEST_CORRELATION_ID} but got {headers['correlation_id']}"
     )
     async with KafkaDLQSubscriber(
         config=config,


### PR DESCRIPTION
The use case for the DLQ subscribers involves using many of them at once, for which the construction model of the regular `KafkaEventSubscriber` is ill-suited. This PR ditches the `construct` method in favor of a normal `__init__` and explicit `start()`, `stop()`. I also included the async context manager functions (`__aenter__()`/`__aexit__()`) to call start and stop since this is helpful for tests where there might only be one subscriber.

I also updated `test_dlqsub.py` to use the blanket `pytestmark` since there was only one sync function.