### PR TITLE
Enable test mode in DLQ .process() (GSI-1291)

### DIFF
--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -790,6 +790,8 @@ class KafkaDLQSubscriber:
             return [ExtractedEventInfo(event) for event in events]
 
     class _PublishingInterceptor:
+        """A mock object to intercept the call to `self._publisher.publish()`."""
+
         def __init__(self):
             self.intercepted: Optional[ExtractedEventInfo] = None
 
@@ -802,6 +804,7 @@ class KafkaDLQSubscriber:
             topic: Ascii,
             headers: Mapping[str, str],
         ) -> None:
+            """Store the intercepted event data as an ExtractedEventInfo instance."""
             self.intercepted = ExtractedEventInfo(
                 payload=payload,
                 type_=type_,
@@ -816,14 +819,14 @@ class KafkaDLQSubscriber:
     ):
         """Intercept the call to `self._publisher.publish()`.
 
-        This context manager will replace the publish method with a mock if
+        This context manager will replace the publish method with `interceptor` if
         `test_only` is `True`.
 
         Args:
-        - `test_only`: If `True`, the publish method will be replaced with a mock that
+        - `test_only`: If `True`, the publish method will be patched with a class that
             captures the published event while maintaining the current offsets.
             This is useful for testing the output of `.process()` without actually
-            publishing to the retry topic/moving the offsets forward.
+            publishing to the retry topic or moving the offsets forward.
             If `False`, the original publish method will be used and offsets committed.
         - `interceptor`: The mock object to use in place of the publisher.
         """
@@ -852,7 +855,7 @@ class KafkaDLQSubscriber:
             next event instead of letting the processor handle it automatically.
         - `test_only`: If `True`, the event will be processed but not published to the
             retry topic. This is useful for double-checking that what would be published
-            matches the expected output.
+            matches the expected output. Offsets will not be committed, like in preview.
         """
         try:
             # Create an interceptor to capture the event that would be published

--- a/tests/integration/test_dlqsub.py
+++ b/tests/integration/test_dlqsub.py
@@ -834,8 +834,8 @@ async def test_process_override(kafka: KafkaFixture):
 
 
 @pytest.mark.asyncio()
-async def test_process_test_result(kafka: KafkaFixture):
-    """Ensure `process` doesn't actually publish the event if `test` is True.
+async def test_process_dry_run(kafka: KafkaFixture):
+    """Ensure `process` doesn't actually publish the event if `dry_run` is True.
 
     Offsets should not be committed.
     Return value should be an ExtractedEventInfo instance with the args that would
@@ -858,8 +858,8 @@ async def test_process_test_result(kafka: KafkaFixture):
         # Verify the event is in the DLQ topic
         assert len(await dlq_subscriber.preview()) == 1
 
-        # Process the event with `test` to see what would be published to the retry topic
-        test_result = await dlq_subscriber.process(test=True)
+        # Process the event with `dry_run` to see what would be published to the retry topic
+        test_result = await dlq_subscriber.process(dry_run=True)
         assert test_result is not None
 
         # Verify that it wasn't actually published and the offset not committed

--- a/tests/integration/test_dlqsub.py
+++ b/tests/integration/test_dlqsub.py
@@ -630,7 +630,8 @@ async def test_default_dlq_processor(
     if validation_error:
         assert len(caplog.records) > 0  # could be more, but should be at least 1
         log = caplog.records[0]
-        assert log.msg.startswith("Ignoring event from DLQ due to validation failure:")
+        expected_log = "Ignoring event from DLQ due to validation failure:"
+        assert log.getMessage().startswith(expected_log)
 
 
 @pytest.mark.parametrize(
@@ -833,11 +834,13 @@ async def test_process_override(kafka: KafkaFixture):
 
 
 @pytest.mark.asyncio()
-async def test_process_test_only(kafka: KafkaFixture):
-    """Ensure `process` doesn't actually publish the event if `test_only` is True.
+async def test_process_test_result(kafka: KafkaFixture):
+    """Ensure `process` doesn't actually publish the event if `test` is True.
 
     Offsets should not be committed.
-    The event that would have been published should be returned.
+    Return value should be an ExtractedEventInfo instance with the args that would
+    have been passed to the publisher. The header modifications that the publisher
+    performs before passing the event to aiokafka are not included.
     """
     config = make_config(kafka.config)
 
@@ -855,8 +858,8 @@ async def test_process_test_only(kafka: KafkaFixture):
         # Verify the event is in the DLQ topic
         assert len(await dlq_subscriber.preview()) == 1
 
-        # Process the event with `test_only` to see what would be published to the retry topic
-        test_result = await dlq_subscriber.process(test_only=True)
+        # Process the event with `test` to see what would be published to the retry topic
+        test_result = await dlq_subscriber.process(test=True)
         assert test_result is not None
 
         # Verify that it wasn't actually published and the offset not committed
@@ -901,3 +904,58 @@ async def test_process_override_different_cid(kafka: KafkaFixture):
         with pytest.raises(DLQProcessingError) as err:
             await dlq_subscriber.process(override=override_event)
         assert err.exconly().endswith(msg)
+
+
+async def test_retry_topic_event_id(kafka: KafkaFixture):
+    """Ensure that the event_id is correctly set when event fails from retry topic.
+
+    The event_id should identify the partition and offset of the failed event, so
+    when generating the event_id, the topic used must be the actual topic it came from.
+    """
+    config = make_config(kafka.config)
+
+    event = ExtractedEventInfo(
+        payload={"test_id": "123456"},
+        type_=TEST_TYPE,
+        topic=TEST_RETRY_TOPIC,
+        key="key",
+        headers={
+            ORIGINAL_TOPIC_FIELD: TEST_TOPIC,
+        },
+    )
+
+    # Publish that event directly to RETRY Topic, as if it had already been requeued
+    async with set_correlation_id(TEST_CORRELATION_ID):
+        await kafka.publisher.publish(**vars(event))
+
+    # Set up dummies and subscriber
+    translator = FailSwitchTranslator(
+        topics_of_interest=[TEST_TOPIC], types_of_interest=[TEST_TYPE], fail=True
+    )
+    async with KafkaEventSubscriber.construct(
+        config=config, translator=translator, dlq_publisher=kafka.publisher
+    ) as event_subscriber:
+        # Consume the event with the event subscriber
+        await event_subscriber.run(forever=False)
+        assert translator.failures
+
+    class PersistentProcessor:
+        def __init__(self):
+            self.called = False
+
+        async def process_event(self, event: ConsumerEvent):
+            """Event processor that makes sure the event_id topic is the retry topic"""
+            self.called = True
+            event_info = ExtractedEventInfo(event)
+            assert "event_id" in event_info.headers
+            assert event_info.headers["event_id"].split(" - ")[0] == TEST_RETRY_TOPIC
+
+    custom_processor = PersistentProcessor()
+    async with KafkaDLQSubscriber(
+        config=config,
+        dlq_topic=TEST_DLQ_TOPIC,
+        dlq_publisher=DummyPublisher(),
+        process_dlq_event=custom_processor.process_event,
+    ) as dlq_subscriber:
+        await dlq_subscriber.process()
+        assert custom_processor.called


### PR DESCRIPTION
### Before this PR:
Call `KafkaDLQSubscriber.process()` to move the next event in the DLQ topic to the appropriate retry-topic. There is no way to be 100% sure what the outcome is (without carefully tracing the code by hand) until you run it. The offsets are committed unless an error causes a crash.

### After this PR:
Call `KafkaDLQSubscriber.process(test_only=True)` to intercept the args passed to `._publisher.publish()` and return them in the form of `ExtractedEventInfo`. The offsets are not committed. The intercept is triggered by a new flag, `dry_run` that is passed through the call chain to `_publish_to_retry()`, where the `dry_run` bool is used to either return the event info or actually publish it.

### Other
- `_get_events()`: Before this PR, only the `preview()` method had reason to reset offsets. Now, so does `process()`. Thus, the logic was consolidated into this context manager. On enter, it records the offsets, and on exit it restores them. The logic was just copy/pasted from `preview()`. The yielded value is the list of events fetched from the broker. On exit, the offsets are either rolled back or committed as dictated by the function args. This CM is used in `preview()` and in `process()`.