### PR TITLE
Consolidate KafkaEventSubscriber and KafkaOutboxSubscriber into the former (GSI-1405)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.0.0"
+version = "4.1.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.0.0"
+version = "4.1.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/providers/akafka/__init__.py
+++ b/src/hexkit/providers/akafka/__init__.py
@@ -21,16 +21,16 @@ respectively.
 
 from .config import KafkaConfig
 from .provider import (
+    ComboTranslator,
     KafkaEventPublisher,
     KafkaEventSubscriber,
     KafkaOutboxSubscriber,
-    TranslatorConverter,
 )
 
 __all__ = [
+    "ComboTranslator",
     "KafkaConfig",
     "KafkaEventPublisher",
     "KafkaEventSubscriber",
     "KafkaOutboxSubscriber",
-    "TranslatorConverter",
 ]

--- a/src/hexkit/providers/akafka/__init__.py
+++ b/src/hexkit/providers/akafka/__init__.py
@@ -24,6 +24,7 @@ from .provider import (
     KafkaEventPublisher,
     KafkaEventSubscriber,
     KafkaOutboxSubscriber,
+    TranslatorConverter,
 )
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "KafkaEventPublisher",
     "KafkaEventSubscriber",
     "KafkaOutboxSubscriber",
+    "TranslatorConverter",
 ]

--- a/src/hexkit/providers/akafka/provider/__init__.py
+++ b/src/hexkit/providers/akafka/provider/__init__.py
@@ -25,6 +25,7 @@ from .eventsub import (
     ConsumerEvent,
     ExtractedEventInfo,
     KafkaEventSubscriber,
+    TranslatorConverter,
     headers_as_dict,
 )
 
@@ -34,5 +35,6 @@ __all__ = [
     "KafkaEventPublisher",
     "KafkaEventSubscriber",
     "KafkaOutboxSubscriber",
+    "TranslatorConverter",
     "headers_as_dict",
 ]

--- a/src/hexkit/providers/akafka/provider/__init__.py
+++ b/src/hexkit/providers/akafka/provider/__init__.py
@@ -22,19 +22,19 @@ Require dependencies of the `akafka` extra.
 from .daosub import KafkaOutboxSubscriber
 from .eventpub import KafkaEventPublisher
 from .eventsub import (
+    ComboTranslator,
     ConsumerEvent,
     ExtractedEventInfo,
     KafkaEventSubscriber,
-    TranslatorConverter,
     headers_as_dict,
 )
 
 __all__ = [
+    "ComboTranslator",
     "ConsumerEvent",
     "ExtractedEventInfo",
     "KafkaEventPublisher",
     "KafkaEventSubscriber",
     "KafkaOutboxSubscriber",
-    "TranslatorConverter",
     "headers_as_dict",
 ]

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -34,7 +34,9 @@ from hexkit.providers.akafka.provider.eventsub import (
     DELETE_EVENT_TYPE,  # noqa: F401  (export for backwards compatibility until v5)
     KafkaConsumerCompatible,
     KafkaEventSubscriber,
-    TranslatorConverter,
+)
+from hexkit.providers.akafka.provider.eventsub import (
+    ComboTranslator as TranslatorConverter,  # for backwards compatibility
 )
 
 
@@ -42,7 +44,7 @@ class KafkaOutboxSubscriber(InboundProviderBase):
     """Apache Kafka-specific provider using translators that implement the
     `DaoSubscriberProtocol`.
 
-    Note: this class can be replaced by using the TranslatorConverter in conjunction
+    Note: this class can be replaced by using the ComboTranslator in conjunction
     with the normal KafkaEventSubscriber class. We may therefore deprecate this
     class in the near future.
     """

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -41,6 +41,10 @@ from hexkit.providers.akafka.provider.eventsub import (
 class KafkaOutboxSubscriber(InboundProviderBase):
     """Apache Kafka-specific provider using translators that implement the
     `DaoSubscriberProtocol`.
+
+    Note: this class can be replaced by using the TranslatorConverter in conjunction
+    with the normal KafkaEventSubscriber class. We may therefore deprecate this
+    class in the near future.
     """
 
     @classmethod

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -19,7 +19,6 @@
 """
 
 import logging
-import warnings
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -68,14 +67,6 @@ class KafkaOutboxSubscriber(InboundProviderBase):
         Returns:
             An instance of the provider.
         """
-        warnings.warn(
-            "KafkaOutboxSubscriber is deprecated and will be removed in hexkit"
-            + " v5. Use KafkaEventSubscriber instead. If you use multiple"
-            + " DaoSubscriberProtocol translators, merge them into a single"
-            + " EventSubscriberProtocol by using the TranslatorConverter class.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
         translator_converter = TranslatorConverter(translators=translators)
 
         if config.kafka_enable_dlq and dlq_publisher is None:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -84,7 +84,7 @@ class TranslatorConverter(EventSubscriberProtocol):
                 # This looks like a looping no-no, but in reality is only a handful of
                 #  iterations and it ensures we route the event to the right translator
                 self.types_of_interest.extend(translator.types_of_interest)
-                non_outbox_topics.extend(translator.topics_of_interest)
+                non_outbox_topics.extend(dict.fromkeys(translator.topics_of_interest))
                 for topic in translator.topics_of_interest:
                     for type_ in translator.types_of_interest:
                         if type_ in self.translators[topic]:
@@ -103,8 +103,8 @@ class TranslatorConverter(EventSubscriberProtocol):
                 "Got multiple DaoSubscriberProtocol-compliant translators trying to"
                 + " consume from the same event topic."
             )
-        self.topics_of_interest.extend(set(outbox_topics))
-        self.topics_of_interest.extend(set(non_outbox_topics))
+        self.topics_of_interest.extend(outbox_topics)
+        self.topics_of_interest.extend(non_outbox_topics)
 
     async def _consume_validated(
         self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: Ascii

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -52,9 +52,13 @@ DELETE_EVENT_TYPE = "deleted"
 EventOrDaoSubProtocol = Union[DaoSubscriberProtocol, EventSubscriberProtocol]
 
 
-class TranslatorConverter(EventSubscriberProtocol):
-    """Takes a list of translators implementing the `DaoSubscriberProtocol` to
-    create a single translator implementing the `EventSubscriberProtocol`.
+class ComboTranslator(EventSubscriberProtocol):
+    """Takes a list of translators implementing either the `DaoSubscriberProtocol`,
+    `EventSubscriberProtocol`, or both, and create a single translator
+    implementing the `EventSubscriberProtocol`. This basically bundles the
+    passed-in translators, with the resulting combo translator acting as a router
+    that directs the event information to the appropriate translator based on
+    its `topic` and `type`.
     """
 
     topics_of_interest: list[str]

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -41,9 +41,9 @@ from hexkit.protocols.dao import (
 from hexkit.protocols.daosub import DaoSubscriberProtocol, DtoValidationError
 from hexkit.protocols.eventsub import EventSubscriberProtocol
 from hexkit.providers.akafka import (
+    ComboTranslator,
     KafkaEventSubscriber,
     KafkaOutboxSubscriber,
-    TranslatorConverter,
 )
 from hexkit.providers.akafka.testutils import (
     ExpectedEvent,
@@ -654,7 +654,7 @@ async def test_dao_pub_sub_happy(
         if subscriber_class == KafkaEventSubscriber:
             construct = partial(
                 KafkaEventSubscriber.construct,
-                translator=TranslatorConverter(translators=[sub_translator]),
+                translator=ComboTranslator(translators=[sub_translator]),
             )
 
         async with construct(config=mongo_kafka.config) as subscriber:

--- a/tests/integration/test_mongokafka.py
+++ b/tests/integration/test_mongokafka.py
@@ -18,6 +18,7 @@
 
 import uuid
 from collections.abc import Generator
+from functools import partial
 from pathlib import Path
 from typing import Any, Optional
 
@@ -38,7 +39,12 @@ from hexkit.protocols.dao import (
     UUID4Field,
 )
 from hexkit.protocols.daosub import DaoSubscriberProtocol, DtoValidationError
-from hexkit.providers.akafka import KafkaOutboxSubscriber
+from hexkit.protocols.eventsub import EventSubscriberProtocol
+from hexkit.providers.akafka import (
+    KafkaEventSubscriber,
+    KafkaOutboxSubscriber,
+    TranslatorConverter,
+)
 from hexkit.providers.akafka.testutils import (
     ExpectedEvent,
     KafkaFixture,  # noqa: F401
@@ -592,7 +598,12 @@ async def test_republishing(mongo_kafka: MongoKafkaFixture):
             await dao.republish()
 
 
-async def test_dao_pub_sub_happy(mongo_kafka: MongoKafkaFixture):
+@pytest.mark.parametrize(
+    "subscriber_class", [KafkaOutboxSubscriber, KafkaEventSubscriber]
+)
+async def test_dao_pub_sub_happy(
+    mongo_kafka: MongoKafkaFixture, subscriber_class: type[EventSubscriberProtocol]
+):
     """Test the happy path of transmitting resource changes or deletions between the
     MongoKafkaOutboxFactory and the KafkaOutboxSubscriber.
 
@@ -637,10 +648,16 @@ async def test_dao_pub_sub_happy(mongo_kafka: MongoKafkaFixture):
         assert get_correlation_id() == initial_correlation_id
 
         # consume events:
-        async with KafkaOutboxSubscriber.construct(
-            config=mongo_kafka.config,
-            translators=[sub_translator],
-        ) as subscriber:
+        construct = partial(
+            KafkaOutboxSubscriber.construct, translators=[sub_translator]
+        )
+        if subscriber_class == KafkaEventSubscriber:
+            construct = partial(
+                KafkaEventSubscriber.construct,
+                translator=TranslatorConverter(translators=[sub_translator]),
+            )
+
+        async with construct(config=mongo_kafka.config) as subscriber:
             for _ in expected_events:
                 await subscriber.run(forever=False)
             assert sub_translator.received == expected_events

--- a/tests/integration/test_translators.py
+++ b/tests/integration/test_translators.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests for the TranslatorConverter behavior.
+"""Integration tests for the ComboTranslator behavior.
 
 There are 4 event schemas defined, which go to three different topics.
 Two of them are outbox events, the other two are non-outbox events.
@@ -29,7 +29,7 @@ from pydantic import BaseModel, Field
 from hexkit.custom_types import Ascii
 from hexkit.protocols.daosub import DaoSubscriberProtocol
 from hexkit.protocols.eventsub import EventSubscriberProtocol
-from hexkit.providers.akafka import KafkaEventSubscriber, TranslatorConverter
+from hexkit.providers.akafka import ComboTranslator, KafkaEventSubscriber
 from hexkit.providers.akafka.config import KafkaConfig
 from hexkit.providers.akafka.testutils import (
     KafkaFixture,
@@ -150,12 +150,12 @@ async def test_merged_translators(kafka: KafkaFixture):
         key=test_event2.my_other_id,
     )
 
-    # Create the translators, then bundle them into one via the TranslatorConverter
+    # Create the translators, then bundle them into one via the ComboTranslator
     non_outbox_translator = DummyEventSubTranslator()
     user_translator = OutboxUserTranslator()
     order_translator = OutboxOrderTranslator()
 
-    super_translator = TranslatorConverter(
+    super_translator = ComboTranslator(
         translators=[non_outbox_translator, user_translator, order_translator]
     )
 
@@ -216,7 +216,7 @@ async def test_merged_translators_retry_topic(kafka: KafkaFixture):
     user_translator = OutboxUserTranslator()
     order_translator = OutboxOrderTranslator()
 
-    super_translator = TranslatorConverter(
+    super_translator = ComboTranslator(
         translators=[non_outbox_translator, user_translator, order_translator]
     )
 

--- a/tests/integration/test_translators.py
+++ b/tests/integration/test_translators.py
@@ -94,7 +94,7 @@ class OutboxUserTranslator(DaoSubscriberProtocol):
 class OutboxOrderTranslator(OutboxUserTranslator):
     """A translator class to subscribe to OrderModel events"""
 
-    dto_model = OrderModel
+    dto_model = OrderModel  # type: ignore[assignment]
     event_topic = "orders"
 
 

--- a/tests/integration/test_translators.py
+++ b/tests/integration/test_translators.py
@@ -1,0 +1,159 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the TranslatorConverter behavior"""
+
+import pytest
+from pydantic import BaseModel, Field
+
+from hexkit.custom_types import Ascii
+from hexkit.protocols.daosub import DaoSubscriberProtocol
+from hexkit.protocols.eventsub import EventSubscriberProtocol
+from hexkit.providers.akafka import KafkaEventSubscriber, TranslatorConverter
+from hexkit.providers.akafka.testutils import (
+    KafkaFixture,
+    kafka_container_fixture,  # noqa: F401
+    kafka_fixture,  # noqa: F401
+)
+
+pytestmark = pytest.mark.asyncio()
+
+
+class UserModel(BaseModel):
+    """A test outbox event"""
+
+    name: str = Field(default="Tom", description="User's name")
+
+
+class OrderModel(BaseModel):
+    """A test outbox event"""
+
+    order_id: str = Field(default="order123", description="The order ID")
+    item_id: str = Field(default="item123", description="The ordered item's ID")
+    complete: bool = Field(
+        default=False, description="Whether the order has been completed"
+    )
+
+
+class SomeEvent(BaseModel):
+    """A test non-outbox event"""
+
+    my_cool_id: str = Field(default="test123", description="Some ID field")
+    some_field: int = Field(default=37, description="Some field with an int")
+
+
+class SomeEvent2(BaseModel):
+    """A test non-outbox event"""
+
+    my_other_id: str = Field(default="test456", description="Some other ID field")
+    some_other_field: int = Field(
+        default=73, description="Some other field with an int"
+    )
+
+
+class OutboxUserTranslator(DaoSubscriberProtocol):
+    """A translator class to subscribe to UserModel events"""
+
+    dto_model = UserModel
+    event_topic = "users"
+
+    def __init__(self):
+        self.upserts: list[tuple[str, UserModel]] = []
+        self.deletes: list[str] = []
+
+    async def changed(self, resource_id: str, update: UserModel) -> None:
+        """Upsert dummy"""
+        self.upserts.append((resource_id, update))
+
+    async def deleted(self, resource_id: str) -> None:
+        """Delete dummy"""
+        self.deletes.append(resource_id)
+
+
+class OutboxOrderTranslator(OutboxUserTranslator):
+    """A translator class to subscribe to OrderModel events"""
+
+    dto_model = OrderModel
+    event_topic = "orders"
+
+
+class DummyEventSubTranslator(EventSubscriberProtocol):
+    """A translator class to subscribe to `TestEvent`, `TestEvent2` events"""
+
+    types_of_interest = ["test_event", "test_event2"]
+    topics_of_interest = ["test-events"]
+
+    def __init__(self):
+        self.consumed: list[tuple[dict, Ascii, Ascii, Ascii]] = []
+
+    async def _consume_validated(  # type: ignore
+        self, *, payload: dict, type_: Ascii, topic: Ascii, key: Ascii
+    ) -> None:
+        self.consumed.append((payload, type_, topic, key))
+
+
+async def test_merged_translators(kafka: KafkaFixture):
+    """Test combining outbox sub translators and non-outbox sub translators in
+    the KafkaEventSubscriber
+    """
+    config = kafka.config
+
+    non_outbox_translator = DummyEventSubTranslator()
+    user_translator = OutboxUserTranslator()
+    order_translator = OutboxOrderTranslator()
+
+    super_translator = TranslatorConverter(
+        translators=[non_outbox_translator, user_translator, order_translator]
+    )
+
+    test_event = SomeEvent()
+    test_event2 = SomeEvent2()
+    user_event = UserModel()
+    order_event = OrderModel()
+
+    # Publish an event of each type
+    await kafka.publish_event(
+        payload=user_event.model_dump(),
+        topic="users",
+        type_="upserted",
+        key=user_event.name,
+    )
+    await kafka.publish_event(
+        payload=order_event.model_dump(),
+        topic="orders",
+        type_="upserted",
+        key=order_event.order_id,
+    )
+    await kafka.publish_event(
+        payload=test_event.model_dump(),
+        topic="test-events",
+        type_="test_event",
+        key=test_event.my_cool_id,
+    )
+    await kafka.publish_event(
+        payload=test_event2.model_dump(),
+        topic="test-events",
+        type_="test_event2",
+        key=test_event2.my_other_id,
+    )
+
+    async with KafkaEventSubscriber.construct(
+        config=config,
+        translator=super_translator,
+    ) as subscriber:
+        await subscriber.run(forever=False)
+        await subscriber.run(forever=False)
+        await subscriber.run(forever=False)
+        await subscriber.run(forever=False)


### PR DESCRIPTION
## Context:
DLQ retry topic subscription in select services

## Problem description:
The services listed below run both event subscribers and outbox subscribers simultaneously.
This has not been a problem until now because the subscribed topics have been mutually exclusive.
The DLQ process introduced retry topics, of which there exists 1 per service. 
Both retried outbox events and retried normal events both get funneled into the same retry topic for a service.
Both the outbox consumer and event consumer try to subscribe to the service's retry topic, but only one gets the events (barring a rebalance).

### Affected Services:
- DINS
- NOS
- IRS
- DCS
- UCS

### Notes:
1. In at least the NOS, the outbox subscriber is used for its intended purpose (cannot simply convert to event subscriber).
2. It is not practical to convert all events in a service to one type or the other as a way to use only one type of subscriber class, since that would require a cascade of changes in other services. 

### Preliminary Conclusion:
Given the problem stems from the fact that there are potentially two running consumers that listen to the same topic,
there are two obvious approaches to fix the problem:
1. Create another retry topic
2. Consolidate the consumers