### PR TITLE
Use separate retry topic for outbox events (GSI-1405)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/providers/akafka/provider/daosub.py
+++ b/src/hexkit/providers/akafka/provider/daosub.py
@@ -42,6 +42,7 @@ from hexkit.providers.akafka.provider.eventsub import (
 
 CHANGE_EVENT_TYPE = "upserted"
 DELETE_EVENT_TYPE = "deleted"
+OUTBOX_RETRY_SUFFIX = "-outbox-retry"
 
 
 class TranslatorConverter(EventSubscriberProtocol):
@@ -141,6 +142,7 @@ class KafkaOutboxSubscriber(InboundProviderBase):
             translator=translator_converter,
             dlq_publisher=dlq_publisher,
             kafka_consumer_cls=kafka_consumer_cls,
+            retry_topic_suffix=OUTBOX_RETRY_SUFFIX,
         ) as event_subscriber:
             yield cls(event_subscriber=event_subscriber)
 


### PR DESCRIPTION
## Context:
DLQ retry topic subscription in select services

## Problem description:
The services listed below run both event subscribers and outbox subscribers simultaneously.
This has not been a problem until now because the subscribed topics have been mutually exclusive.
The DLQ process introduced retry topics, of which there exists 1 per service. 
Both retried outbox events and retried normal events both get funneled into the same retry topic for a service.
Both the outbox consumer and event consumer try to subscribe to the service's retry topic, but only one gets the events (barring a rebalance).

### Affected Services:
- DINS
- NOS
- IRS
- DCS
- UCS

### Notes:
1. In at least the NOS, the outbox subscriber is used for its intended purpose (cannot simply convert to event subscriber).
2. It is not practical to convert all events in a service to one type or the other as a way to use only one type of subscriber class, since that would require a cascade of changes in other services. 

### Preliminary Conclusion:
Given the problem stems from the fact that there are potentially two running consumers that listen to the same topic,
there are two obvious approaches to fix the problem:
1. Create another retry topic
2. Consolidate the consumers