### PR TITLE
Always add traceback if configured (GSI-1415)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.1.0"
+version = "4.1.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.1.0"
+version = "4.1.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -118,13 +118,17 @@ class JsonFormatter(Formatter):
         output["details"] = log_record["details"]
 
         if log_record["exc_info"]:
-            exc_type, exc_value = log_record["exc_info"][:2]
+            exc_info = log_record["exc_info"]
+            exc_type, exc_value = exc_info[:2]
             exception = {
                 "type": exc_type.__name__,
                 "message": str(exc_value),
             }
             if self._include_traceback:
                 exc_text = log_record["exc_text"]
+                if not exc_text:
+                    # if there is not pre-formatted cached traceback, create it
+                    exc_text = super().formatException(exc_info)
                 if exc_text:
                     exception["traceback"] = exc_text
             output["exception"] = exception


### PR DESCRIPTION
This PR fixes the problem that sometimes when an error is raised, the formatted traceback text has no been cached, and needs to be generated in the JSON formatter.