### PR TITLE
Aiokafka extended OpenTelemetry support

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.4.0"
+version = "4.3.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.3.0"
+version = "4.4.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [
@@ -17,6 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 dependencies = [
+    "opentelemetry-api>=1.31.1, <2",
     "pydantic >=2.10, <3",
     "pydantic_settings >=2.8, <3",
     "PyYAML >=6, <7",

--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=78.0.2"]
+requires = ["setuptools>=78.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/.readme_generation/readme_template.md
+++ b/.readme_generation/readme_template.md
@@ -91,8 +91,8 @@ Then open this repository in VS Code and run the command
 This will give you a full-fledged, pre-configured development environment including:
 - infrastructural dependencies of the service (databases, etc.)
 - all relevant VS Code extensions pre-installed
-- preconfigured linting and auto-formatting
-- a preconfigured debugger
+- pre-configured linting and auto-formatting
+- a pre-configured debugger
 - automatic license-header insertion
 
 Moreover, inside the devcontainer, a command `dev_install` is available for convenience.

--- a/.readme_generation/readme_template.md
+++ b/.readme_generation/readme_template.md
@@ -13,7 +13,7 @@ $description
 
 We recommend using the provided Docker container.
 
-A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/$name):
+A pre-built version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/$name):
 ```bash
 docker pull ghga/$name:$version
 ```
@@ -50,11 +50,11 @@ $config_description
 
 ### Usage:
 
-A template YAML for configurating the service can be found at
+A template YAML for configuring the service can be found at
 [`./example-config.yaml`](./example-config.yaml).
-Please adapt it, rename it to `.$shortname.yaml`, and place it into one of the following locations:
-- in the current working directory were you are execute the service (on unix: `./.$shortname.yaml`)
-- in your home directory (on unix: `~/.$shortname.yaml`)
+Please adapt it, rename it to `.$shortname.yaml`, and place it in one of the following locations:
+- in the current working directory where you execute the service (on Linux: `./.$shortname.yaml`)
+- in your home directory (on Linux: `~/.$shortname.yaml`)
 
 The config yaml will be automatically parsed by the service.
 
@@ -68,7 +68,7 @@ e.g. for the `host` set an environment variable named `${shortname}_host`
 (you may use both upper or lower cases, however, it is standard to define all env
 variables in upper cases).
 
-To using file secrets please refer to the
+To use file secrets, please refer to the
 [corresponding section](https://pydantic-docs.helpmanual.io/usage/settings/#secret-support)
 of the pydantic documentation.
 
@@ -91,12 +91,12 @@ Then open this repository in VS Code and run the command
 This will give you a full-fledged, pre-configured development environment including:
 - infrastructural dependencies of the service (databases, etc.)
 - all relevant VS Code extensions pre-installed
-- pre-configured linting and auto-formatting
-- a pre-configured debugger
+- preconfigured linting and auto-formatting
+- a preconfigured debugger
 - automatic license-header insertion
 
-Moreover, inside the devcontainer, a convenience commands `dev_install` is available.
-It installs the service with all development dependencies, installs pre-commit.
+Moreover, inside the devcontainer, a command `dev_install` is available for convenience.
+It installs the service with all development dependencies, and it installs pre-commit.
 
 The installation is performed automatically when you build the devcontainer. However,
 if you update dependencies in the [`./pyproject.toml`](./pyproject.toml) or the

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -23,10 +23,10 @@ urllib3>=2.3
 requests>=2.31
 
 casefy>=1.1
-jsonschema2md>=1.4
-setuptools>=78.0.2
+jsonschema2md>=1.5
+setuptools>=78.1
 
 # required since switch to pyproject.toml and pip-tools
 tomli_w>=1.2
 
-uv>=0.6.9
+uv>=0.6.10

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -49,13 +49,13 @@ attrs==25.3.0 \
     # via
     #   jsonschema
     #   referencing
-boto3==1.37.19 \
-    --hash=sha256:c69c90500f18fd72d782d1612170b7d3db9a98ed51a4da3bebe38e693497ebf8 \
-    --hash=sha256:fbfc2c43ad686b63c8aa02aee634c269f856eed68941d8e570cc45950be52130
+boto3==1.37.20 \
+    --hash=sha256:225dbc75d79816cb9b28cc74a63c9fa0f2d70530d603dacd82634f362f6679c1 \
+    --hash=sha256:87d9bd6ad49be754d4ae2724cfb892eb3f9f17bcafd781fb3ce0d98cc539bdd6
     # via hexkit (pyproject.toml)
-botocore==1.37.19 \
-    --hash=sha256:6e1337e73a6b8146c1ec20a6a72d67e2809bd4c0af076431fe6e1561e0c89415 \
-    --hash=sha256:eadcdc37de09df25cf1e62e8106660c61f60a68e984acfc1a8d43fb6267e53b8
+botocore==1.37.20 \
+    --hash=sha256:9295385740f9d30f9b679f76ee51f49b80ae73183d84d499c1c3f1d54d820f54 \
+    --hash=sha256:c34f4f25fda7c4f726adf5a948590bd6bd7892c05278d31e344b5908e7b43301
     # via
     #   hexkit (pyproject.toml)
     #   boto3
@@ -358,6 +358,10 @@ cryptography==44.0.2 \
     --hash=sha256:efcfe97d1b3c79e486554efddeb8f6f53a4cdd4cf6086642784fa31fc384e1d7 \
     --hash=sha256:f514ef4cd14bb6fb484b4a60203e912cfcb64f2ab139e88c2274511514bf7308
     # via -r lock/requirements-dev.in
+deprecated==1.2.18 \
+    --hash=sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d \
+    --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
+    # via opentelemetry-api
 distlib==0.3.9 \
     --hash=sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87 \
     --hash=sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403
@@ -405,6 +409,10 @@ idna==3.10 \
     #   anyio
     #   httpx
     #   requests
+importlib-metadata==8.6.1 \
+    --hash=sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e \
+    --hash=sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580
+    # via opentelemetry-api
 iniconfig==2.1.0 \
     --hash=sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7 \
     --hash=sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760
@@ -487,6 +495,10 @@ nodeenv==1.9.1 \
     --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
     --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
     # via pre-commit
+opentelemetry-api==1.31.1 \
+    --hash=sha256:137ad4b64215f02b3000a0292e077641c8611aab636414632a9b9068593b7e91 \
+    --hash=sha256:1511a3f470c9c8a32eeea68d4ea37835880c0eed09dd1a0187acc8b1301da0a1
+    # via hexkit (pyproject.toml)
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
@@ -931,9 +943,9 @@ s3transfer==0.11.4 \
     --hash=sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679 \
     --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
     # via boto3
-setuptools==78.0.2 \
-    --hash=sha256:137525e6afb9022f019d6e884a319017f9bf879a0d8783985d32cbc8683cab93 \
-    --hash=sha256:4a612c80e1f1d71b80e4906ce730152e8dec23df439f82731d9d0b608d7b700d
+setuptools==78.1.0 \
+    --hash=sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54 \
+    --hash=sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8
     # via -r lock/requirements-dev-template.in
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
@@ -1014,16 +1026,14 @@ typer==0.15.2 \
     --hash=sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc \
     --hash=sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5
     # via -r lock/requirements-dev-template.in
-typing-extensions==4.12.2 \
-    --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
-    --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
+typing-extensions==4.13.0 \
+    --hash=sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b \
+    --hash=sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5
     # via
     #   aiokafka
-    #   anyio
     #   mypy
     #   pydantic
     #   pydantic-core
-    #   referencing
     #   testcontainers
     #   typer
 urllib3==2.3.0 \
@@ -1035,25 +1045,25 @@ urllib3==2.3.0 \
     #   docker
     #   requests
     #   testcontainers
-uv==0.6.9 \
-    --hash=sha256:04cd4a9567bcf3b5ed7746aa59077e261eb0a61fe8bc46b05416ee33ea132a77 \
-    --hash=sha256:4e1cf5e02e7b7ca7d3ae8681cdbca79fdb2bb1a005a2ecc0e3f4fcccc664403d \
-    --hash=sha256:5d4e1b62c86c9e0d16973df3db1ce0d448ca69708bbecf0e79b629debb540a07 \
-    --hash=sha256:7932640314e4b3b7416a07ef553667e1f113d25a67690fa0e00f1be7f1c20385 \
-    --hash=sha256:8112cac95281e3319a5b1320175e0a3c7d1d5be1f147a50e1f40d0bd3563c7f5 \
-    --hash=sha256:8239c5e77dbce87211588f58f6d91ba30ceea03569baa2d3830860017e9dc13d \
-    --hash=sha256:8e2db4fd0dc8aff8e7db1861022578f04c0b685d6cd9b81a0b1f7c2bcfa9947b \
-    --hash=sha256:915766098127cd47aa682907b3dbe3c5206de6655d014f05415b061c40270e37 \
-    --hash=sha256:9285b2d6bee0cfd7baa70570478f3c60b33450fd50ccbe03343a7cc5d9880dd4 \
-    --hash=sha256:ab6b55d14450175e79a8a819fc2728bfb6adf289ce03ab312654091fa7f6101a \
-    --hash=sha256:b40a75f854736d103207aa706569a561c4018eaeebf4474debb2f102d5c9097c \
-    --hash=sha256:bd7534c0b78b3dcaf1ac394b181ee09040e95aeaa93f8c0701e495f98bbb7fe5 \
-    --hash=sha256:c742df7a174ce1e16192108a28658cd7292af63c34cb9a9d4b683d3678737fbb \
-    --hash=sha256:c7bcd1312d066e4c8f85b450fc9879971733ef363ae9159bc24e832ad5e4a803 \
-    --hash=sha256:ccc990a05ca500d98a67fe70b48f342f7e5b2f4cc32433f39f7aa34117e20dc3 \
-    --hash=sha256:e2351e8388fbe70c821aaa32da825a4ced91c42f4608a3833af606710e64a725 \
-    --hash=sha256:e9973a4e86249c10a39c80bd8ca284b103a0408b639e31ef764e5eb670c30382 \
-    --hash=sha256:ffe6f6c8df7814b82cf9f6cc2cca0057e9bb3398b0538ecad3bf97664b1ffa99
+uv==0.6.10 \
+    --hash=sha256:06932d36f1afaf611522a6a7ec361dac48dc67a1147d24e9eadee9703b15faaf \
+    --hash=sha256:13ac09945976dc0df0edde7e4ba3a46107036a114117c8ff84916e55216c2e32 \
+    --hash=sha256:145e75b99d6b7bdce8e454a851cfcd5605ff0491d568244c66fa75ca6b071bd6 \
+    --hash=sha256:4dd20c47898c15ebd4b5f48101062ea248e32513bfc61fc04bc822abfe39ce8a \
+    --hash=sha256:5188dc7041f4166bf64182d76c32c873f750259b6e4621a1400c26ebeea8c8dd \
+    --hash=sha256:5260f52386e217615553f2f42740ce2f64ba439ff0fd502dc5b06250eb8ae613 \
+    --hash=sha256:603aebbaf6be938120c73fd36e9fd85f5e1b671d3d4638b3086f478e2bb423d9 \
+    --hash=sha256:666d9fe312c810bba77633dbd463dc85f5a6a0d07905726a014dc53d07c774d9 \
+    --hash=sha256:950c9cd7b75f67e25760d2f43ad4b0ee3f8c6724fe0a9cf9eff948b3044b6a6d \
+    --hash=sha256:acca1dca7be342b2b8e26e509aa07c3144cb009788140eee045da2aad6a0c6fe \
+    --hash=sha256:b98e8884093cbfb1a1cc3f855aa22f97ec8da1a87e0e761800e165d4f9224a45 \
+    --hash=sha256:cbbb03deb30af457cd93ad299ee5c3258ade3d900b4dee1af936c8a6d87d5bcb \
+    --hash=sha256:cd8a4bcfd33a0dcae3fc0936bff8602f74e5719cf839e3df233059a0b8c8330d \
+    --hash=sha256:d1f1bc7d94a4a7fdd75142be71b6bf2d7e01282f322721da185d711f065d7b80 \
+    --hash=sha256:d795721fdd32e0471c952b7cb02a030657b6e67625fe836f4df14a3ae4aa4921 \
+    --hash=sha256:df6560256b93441c70ea2c062975bce2307a32de280f103cedb8db4a0f542348 \
+    --hash=sha256:e5c2ba1922c47a245d7393465fcee942df5a8bd8b80489a7b8860ba9d60102f9 \
+    --hash=sha256:e8a8a75cf34c0814c1eabdbe651741d44fb125a6dcbe159b2da02871bbfdec7e
     # via -r lock/requirements-dev-template.in
 virtualenv==20.29.3 \
     --hash=sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170 \
@@ -1141,4 +1151,10 @@ wrapt==1.17.2 \
     --hash=sha256:f917c1180fdb8623c2b75a99192f4025e412597c50b2ac870f156de8fb101119 \
     --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
     --hash=sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58
-    # via testcontainers
+    # via
+    #   deprecated
+    #   testcontainers
+zipp==3.21.0 \
+    --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
+    --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
+    # via importlib-metadata

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -431,14 +431,18 @@ jsonschema-specifications==2024.10.1 \
     --hash=sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272 \
     --hash=sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf
     # via jsonschema
-jsonschema2md==1.4.0 \
-    --hash=sha256:672a6faec9f04ef571dd950a9d5f3a29408d0208ac0639c845fc0b289aabb155 \
-    --hash=sha256:942a00f8ed5d3ea6a0934a229a60b8d14e26e302cef06a68ea00baec19afae17
+jsonschema2md==1.5.0 \
+    --hash=sha256:6441a45483e7796932638842e2329440242384a801a7594302a6e9b490b52aad \
+    --hash=sha256:fb003c12d4debeba1a38c24830d04445807ca4043583bde96b9d0bb7cfa1af56
     # via -r lock/requirements-dev-template.in
 logot==1.3.0 \
     --hash=sha256:bb2e8cf8ca949015e1e096e45023095ebd5df06ea4627f5df47d53dcdf62b74e \
     --hash=sha256:de392d182308828a0a9a442120e25e4ad2258fef52c4ed275e012aaffb0514a5
     # via -r lock/requirements-dev-template.in
+markdown==3.7 \
+    --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
+    --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
+    # via jsonschema2md
 markdown-it-py==3.0.0 \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
     --hash=sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -52,15 +52,15 @@ attrs==25.3.0 \
     #   -c lock/requirements-dev.txt
     #   jsonschema
     #   referencing
-boto3==1.37.19 \
-    --hash=sha256:c69c90500f18fd72d782d1612170b7d3db9a98ed51a4da3bebe38e693497ebf8 \
-    --hash=sha256:fbfc2c43ad686b63c8aa02aee634c269f856eed68941d8e570cc45950be52130
+boto3==1.37.20 \
+    --hash=sha256:225dbc75d79816cb9b28cc74a63c9fa0f2d70530d603dacd82634f362f6679c1 \
+    --hash=sha256:87d9bd6ad49be754d4ae2724cfb892eb3f9f17bcafd781fb3ce0d98cc539bdd6
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit (pyproject.toml)
-botocore==1.37.19 \
-    --hash=sha256:6e1337e73a6b8146c1ec20a6a72d67e2809bd4c0af076431fe6e1561e0c89415 \
-    --hash=sha256:eadcdc37de09df25cf1e62e8106660c61f60a68e984acfc1a8d43fb6267e53b8
+botocore==1.37.20 \
+    --hash=sha256:9295385740f9d30f9b679f76ee51f49b80ae73183d84d499c1c3f1d54d820f54 \
+    --hash=sha256:c34f4f25fda7c4f726adf5a948590bd6bd7892c05278d31e344b5908e7b43301
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit (pyproject.toml)
@@ -168,6 +168,12 @@ charset-normalizer==3.4.1 \
     # via
     #   -c lock/requirements-dev.txt
     #   requests
+deprecated==1.2.18 \
+    --hash=sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d \
+    --hash=sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec
+    # via
+    #   -c lock/requirements-dev.txt
+    #   opentelemetry-api
 dnspython==2.7.0 \
     --hash=sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86 \
     --hash=sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1
@@ -186,6 +192,12 @@ idna==3.10 \
     # via
     #   -c lock/requirements-dev.txt
     #   requests
+importlib-metadata==8.6.1 \
+    --hash=sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e \
+    --hash=sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580
+    # via
+    #   -c lock/requirements-dev.txt
+    #   opentelemetry-api
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
@@ -208,6 +220,12 @@ jsonschema-specifications==2024.10.1 \
 motor==3.7.0 \
     --hash=sha256:0dfa1f12c812bd90819c519b78bed626b5a9dbb29bba079ccff2bfa8627e0fec \
     --hash=sha256:61bdf1afded179f008d423f98066348157686f25a90776ea155db5f47f57d605
+    # via
+    #   -c lock/requirements-dev.txt
+    #   hexkit (pyproject.toml)
+opentelemetry-api==1.31.1 \
+    --hash=sha256:137ad4b64215f02b3000a0292e077641c8611aab636414632a9b9068593b7e91 \
+    --hash=sha256:1511a3f470c9c8a32eeea68d4ea37835880c0eed09dd1a0187acc8b1301da0a1
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit (pyproject.toml)
@@ -604,15 +622,14 @@ testcontainers==4.9.2 \
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit (pyproject.toml)
-typing-extensions==4.12.2 \
-    --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
-    --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
+typing-extensions==4.13.0 \
+    --hash=sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b \
+    --hash=sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5
     # via
     #   -c lock/requirements-dev.txt
     #   aiokafka
     #   pydantic
     #   pydantic-core
-    #   referencing
     #   testcontainers
 urllib3==2.3.0 \
     --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
@@ -705,4 +722,11 @@ wrapt==1.17.2 \
     --hash=sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58
     # via
     #   -c lock/requirements-dev.txt
+    #   deprecated
     #   testcontainers
+zipp==3.21.0 \
+    --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
+    --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
+    # via
+    #   -c lock/requirements-dev.txt
+    #   importlib-metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=78.0.2",
+    "setuptools>=78.1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.3.0"
+version = "4.4.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
+    "opentelemetry-api>=1.31.1, <2",
     "pydantic >=2.10, <3",
     "pydantic_settings >=2.8, <3",
     "PyYAML >=6, <7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.4.0"
+version = "4.3.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api>=1.31.1, <2",

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -645,7 +645,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             getter=otel_extractor,
         )
         with tracer.start_as_current_span(
-            name="Consume event", context=extracted_context
+            name="KafkaEventSubscriber._consume_event", context=extracted_context
         ):
             event_id = get_event_id(event, service_name=self._service_name)
             event_info = self._extract_info(event)

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -53,7 +53,7 @@ from hexkit.providers.akafka.provider.utils import (
 CHANGE_EVENT_TYPE = "upserted"
 DELETE_EVENT_TYPE = "deleted"
 EventOrDaoSubProtocol = Union[DaoSubscriberProtocol, EventSubscriberProtocol]
-TextmapHeaders = list[tuple[str, Optional[bytes]]]
+TextmapHeaders = list[tuple[str, bytes]]
 
 tracer = trace.get_tracer_provider().get_tracer("hexkit.providers.akafka")
 
@@ -642,7 +642,7 @@ class KafkaEventSubscriber(InboundProviderBase):
         otel_extractor = AIOKafkaOtelContextExtractor()
         extracted_context = extract(
             event.headers,
-            getter=otel_extractor,  # type: ignore
+            getter=otel_extractor,
         )
         with tracer.start_as_current_span(
             name="Consume event", context=extracted_context

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -33,6 +33,9 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Literal, Optional, Protocol, TypeVar, Union, cast
 
 from aiokafka import AIOKafkaConsumer
+from opentelemetry import trace
+from opentelemetry.propagate import extract
+from opentelemetry.propagators import textmap
 from pydantic import ValidationError
 
 from hexkit.base import InboundProviderBase
@@ -50,6 +53,32 @@ from hexkit.providers.akafka.provider.utils import (
 CHANGE_EVENT_TYPE = "upserted"
 DELETE_EVENT_TYPE = "deleted"
 EventOrDaoSubProtocol = Union[DaoSubscriberProtocol, EventSubscriberProtocol]
+TextmapHeaders = list[tuple[str, Optional[bytes]]]
+
+tracer = trace.get_tracer_provider().get_tracer("hexkit.providers.akafka")
+
+
+class AIOKafkaOtelContextExtractor(textmap.Getter[TextmapHeaders]):
+    """OpenTelemetry context extractor.
+
+    This is slighlty adapted from the aiokafka instrumentation library.
+    """
+
+    def get(self, carrier: TextmapHeaders, key: str) -> Optional[list[str]]:
+        """Extract specific OpenTelemetry header from propagated context"""
+        if carrier is None:
+            return None
+
+        for item_key, value in carrier:
+            if item_key == key and value is not None:
+                return [value.decode()]
+        return None
+
+    def keys(self, carrier: TextmapHeaders) -> list[str]:
+        """Get all headers from propagated context"""
+        if carrier is None:
+            return []
+        return [key for (key, value) in carrier]
 
 
 class ComboTranslator(EventSubscriberProtocol):
@@ -610,39 +639,49 @@ class KafkaEventSubscriber(InboundProviderBase):
 
     async def _consume_event(self, event: ConsumerEvent) -> None:
         """Consume an event by passing it down to the translator via the protocol."""
-        event_id = get_event_id(event, service_name=self._service_name)
-        event_info = self._extract_info(event)
-        try:
-            self._validate_extracted_info(event_info)
-        except RuntimeError as err:
-            logging.info(
-                "Ignored event of type '%s': %s, errors: %s",
-                event_info.type_,
-                event_id,
-                str(err),
-            )
-            # Always acknowledge event receipt for ignored events
-            await self._consumer.commit()
-            return
+        otel_extractor = AIOKafkaOtelContextExtractor()
+        extracted_context = extract(
+            event.headers,
+            getter=otel_extractor,  # type: ignore
+        )
+        with tracer.start_as_current_span(
+            name="Consume event", context=extracted_context
+        ):
+            event_id = get_event_id(event, service_name=self._service_name)
+            event_info = self._extract_info(event)
+            try:
+                self._validate_extracted_info(event_info)
+            except RuntimeError as err:
+                logging.info(
+                    "Ignored event of type '%s': %s, errors: %s",
+                    event_info.type_,
+                    event_id,
+                    str(err),
+                )
+                # Always acknowledge event receipt for ignored events
+                await self._consumer.commit()
+                return
 
-        try:
-            logging.info("Consuming event of type '%s': %s", event_info.type_, event_id)
-            correlation_id = event_info.headers[HeaderNames.CORRELATION_ID]
-            async with set_correlation_id(correlation_id):
-                await self._handle_consumption(event=event_info, event_id=event_id)
-        except Exception:
-            # Errors only bubble up here if the DLQ isn't used
-            logging.critical(
-                "An error occurred while processing event of type '%s': %s. It was NOT"
-                " placed in the DLQ topic (%s)",
-                event_info.type_,
-                event_id,
-                self._dlq_topic if self._enable_dlq else "DLQ is disabled",
-            )
-            raise
-        else:
-            # Only save consumed event offsets if it was successful or sent to DLQ
-            await self._consumer.commit()
+            try:
+                logging.info(
+                    "Consuming event of type '%s': %s", event_info.type_, event_id
+                )
+                correlation_id = event_info.headers[HeaderNames.CORRELATION_ID]
+                async with set_correlation_id(correlation_id):
+                    await self._handle_consumption(event=event_info, event_id=event_id)
+            except Exception:
+                # Errors only bubble up here if the DLQ isn't used
+                logging.critical(
+                    "An error occurred while processing event of type '%s': %s. It was NOT"
+                    " placed in the DLQ topic (%s)",
+                    event_info.type_,
+                    event_id,
+                    self._dlq_topic if self._enable_dlq else "DLQ is disabled",
+                )
+                raise
+            else:
+                # Only save consumed event offsets if it was successful or sent to DLQ
+                await self._consumer.commit()
 
     async def run(self, forever: bool = True) -> None:
         """Start consuming events and passing them down to the translator.


### PR DESCRIPTION
This PR adds some OpenTelemetry specific code to properly support cross service context propagation using AIOKafka.
This is needed due to the combination of two specific circumstances:
1) The aiokafka instrumentation library returns to the previously opened context and does not open a new child span. Thus a parent span using the propagated context is needed to link between the incoming event context and downstream spans.
2) The parent span needs to be opened before event consumption, but needs access to the headers to extract the context. Service code does not have access to Kafka headers, so this has to happen in hexkit.

Lines 650+ in `event_sub` are unchanged, just indented due to to context manager use.