### PR TITLE
OpenTelemetry Tracer decorator + set default exporter protocol to http/protobuf 

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "4.4.1"
+version = "4.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "4.4.1"
+version = "4.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.31.1, <2",

--- a/src/hexkit/opentelemetry_setup.py
+++ b/src/hexkit/opentelemetry_setup.py
@@ -44,20 +44,21 @@ class SpanTracer:
         self.tracer = trace.get_tracer(name)
 
     def start_span(
-        self,
-        function: Callable,
-        record_exception: bool = False,
-        set_status_on_exception: bool = False,
+        self, *, record_exception: bool = False, set_status_on_exception: bool = False
     ):
         """Decorator function starting a span populated with the __qualname__ of the wrapped function"""
 
-        def traced_function(*args, **kwargs):
-            name = function.__qualname__
-            with self.tracer.start_as_current_span(
-                name,
-                record_exception=record_exception,
-                set_status_on_exception=set_status_on_exception,
-            ):
-                return function(*args, **kwargs)
+        def outer_wrapper(function: Callable):
+            def traced_function(*args, **kwargs):
+                name = function.__qualname__
+                with self.tracer.start_as_current_span(
+                    name,
+                    record_exception=record_exception,
+                    set_status_on_exception=set_status_on_exception,
+                ):
+                    print(name)
+                    return function(*args, **kwargs)
 
-        return traced_function
+            return traced_function
+
+        return outer_wrapper

--- a/src/hexkit/opentelemetry_setup.py
+++ b/src/hexkit/opentelemetry_setup.py
@@ -43,12 +43,21 @@ class SpanTracer:
     def __init__(self, name):
         self.tracer = trace.get_tracer(name)
 
-    def start_span(self, function: Callable):
+    def start_span(
+        self,
+        function: Callable,
+        record_exception: bool = False,
+        set_status_on_exception: bool = False,
+    ):
         """Decorator function starting a span populated with the __qualname__ of the wrapped function"""
 
         def traced_function(*args, **kwargs):
             name = function.__qualname__
-            with self.tracer.start_as_current_span(name):
+            with self.tracer.start_as_current_span(
+                name,
+                record_exception=record_exception,
+                set_status_on_exception=set_status_on_exception,
+            ):
                 return function(*args, **kwargs)
 
         return traced_function

--- a/src/hexkit/opentelemetry_setup.py
+++ b/src/hexkit/opentelemetry_setup.py
@@ -27,7 +27,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 def configure_tracer(service_name: str, protocol: str = "http/protobuf"):
     """Set up a global tracer for a specific service using the given exporter protocol."""
-    # opentelemetry distro sets this to grpc, but in the current context http/protobuf is prefered
+    # opentelemetry distro sets this to grpc, but in the current context http/protobuf is preferred
     os.environ.setdefault(OTEL_EXPORTER_OTLP_PROTOCOL, protocol)
 
     resource = Resource(attributes={SERVICE_NAME: service_name})

--- a/src/hexkit/opentelemetry_setup.py
+++ b/src/hexkit/opentelemetry_setup.py
@@ -56,7 +56,6 @@ class SpanTracer:
                     record_exception=record_exception,
                     set_status_on_exception=set_status_on_exception,
                 ):
-                    print(name)
                     return function(*args, **kwargs)
 
             return traced_function

--- a/src/hexkit/opentelemetry_setup.py
+++ b/src/hexkit/opentelemetry_setup.py
@@ -44,7 +44,7 @@ class SpanTracer:
         self.tracer = trace.get_tracer(name)
 
     def start_span(self, function: Callable):
-        """Decorator function starting a span populated with the function __qualname__"""
+        """Decorator function starting a span populated with the __qualname__ of the wrapped function"""
 
         def traced_function(*args, **kwargs):
             name = function.__qualname__


### PR DESCRIPTION
Adds a custom `SpanTracer` class that holds the tracer instance and provides a decorator method that automatically starts a span and populates its name with the function `__qualname__`.

Also extends `configure_tracer` to allow to set a default exporter protocol programmatically like the `opentelemetry-distro` library does, but instead of setting `grpc` as default, `http/protobuf` is set.