### PR TITLE
Introduce New Kafka Event ID Header (GSI-1713)

### DIFF
--- a/examples/stream_calc/sc_tests/unit/test_eventsub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventsub.py
@@ -27,6 +27,8 @@ from stream_calc.translators.eventsub import (
     EventProblemReceiverConfig,
 )
 
+TEST_EVENT_ID = UUID("12345678-1234-5678-1234-567812345678")
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -55,9 +57,9 @@ async def test_event_problem_receiver(
     problem_receiver = EventProblemReceiver(
         config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
-    event_id = UUID("12345678-1234-5678-1234-567812345678")
+
     await problem_receiver.consume(
-        payload=payload, type_=type_, topic=topic, key="test", event_id=event_id
+        payload=payload, type_=type_, topic=topic, key="test", event_id=TEST_EVENT_ID
     )
 
     # check the published event:
@@ -75,12 +77,15 @@ async def test_event_problem_receiver_with_missing_field():
     problem_receiver = EventProblemReceiver(
         config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
-    event_id = UUID("12345678-1234-5678-1234-567812345678")
     with pytest.raises(
         EventProblemReceiver.MalformedPayloadError,
         match="did not contain the expected field 'multiplicand'",
     ):
         await problem_receiver.consume(
-            payload=payload, type_=type_, topic=topic, key="test", event_id=event_id
+            payload=payload,
+            type_=type_,
+            topic=topic,
+            key="test",
+            event_id=TEST_EVENT_ID,
         )
     problem_handler.multiply.assert_not_awaited()

--- a/examples/stream_calc/sc_tests/unit/test_eventsub.py
+++ b/examples/stream_calc/sc_tests/unit/test_eventsub.py
@@ -17,6 +17,7 @@
 """Testing the `translators.eventsub` module."""
 
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 
@@ -54,8 +55,9 @@ async def test_event_problem_receiver(
     problem_receiver = EventProblemReceiver(
         config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
     await problem_receiver.consume(
-        payload=payload, type_=type_, topic=topic, key="test"
+        payload=payload, type_=type_, topic=topic, key="test", event_id=event_id
     )
 
     # check the published event:
@@ -73,11 +75,12 @@ async def test_event_problem_receiver_with_missing_field():
     problem_receiver = EventProblemReceiver(
         config=EventProblemReceiverConfig(), problem_handler=problem_handler
     )
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
     with pytest.raises(
         EventProblemReceiver.MalformedPayloadError,
         match="did not contain the expected field 'multiplicand'",
     ):
         await problem_receiver.consume(
-            payload=payload, type_=type_, topic=topic, key="test"
+            payload=payload, type_=type_, topic=topic, key="test", event_id=event_id
         )
     problem_handler.multiply.assert_not_awaited()

--- a/examples/stream_calc/stream_calc/translators/eventsub.py
+++ b/examples/stream_calc/stream_calc/translators/eventsub.py
@@ -16,6 +16,7 @@
 
 """Translators that target the event publishing protocol."""
 
+from pydantic import UUID4
 from pydantic_settings import BaseSettings
 
 from hexkit.custom_types import Ascii, JsonObject
@@ -70,6 +71,7 @@ class EventProblemReceiver(EventSubscriberProtocol):
         # provided as part of the EventSubscriberProtocol:
         topic: Ascii,
         key: Ascii,
+        event_id: UUID4,
     ) -> None:
         """
         Receive and process an event with already validated topic, type, and key.
@@ -79,6 +81,7 @@ class EventProblemReceiver(EventSubscriberProtocol):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
         """
 
         if type_ == "multiplication_problem":

--- a/src/hexkit/protocols/eventpub.py
+++ b/src/hexkit/protocols/eventpub.py
@@ -19,6 +19,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from typing import Optional
+from uuid import UUID, uuid4
+
+from pydantic import UUID4
 
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.utils import check_ascii
@@ -27,13 +30,14 @@ from hexkit.utils import check_ascii
 class EventPublisherProtocol(ABC):
     """A protocol for publishing events to an event broker."""
 
-    async def publish(
+    async def publish(  # noqa: PLR0913
         self,
         *,
         payload: JsonObject,
         type_: Ascii,
         key: Ascii,
         topic: Ascii,
+        event_id: Optional[UUID4] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """Publish an event.
@@ -43,8 +47,16 @@ class EventPublisherProtocol(ABC):
         - `type_` (str): The event type. ASCII characters only.
         - `key` (str): The event type. ASCII characters only.
         - `topic` (str): The event type. ASCII characters only.
+        - `event_id` (UUID4, optional): An optional event ID. If not provided, a new
+          one will be generated.
         - `headers`: Additional headers to attach to the event.
         """
+        if event_id:
+            if not isinstance(event_id, UUID):
+                raise TypeError(f"event_id must be a UUID, got {type(event_id)}")
+        else:
+            event_id = uuid4()
+
         check_ascii(type_, key, topic)
         if headers is None:
             headers = {}
@@ -54,17 +66,19 @@ class EventPublisherProtocol(ABC):
             type_=type_,
             key=key,
             topic=topic,
+            event_id=event_id,
             headers=headers,
         )
 
     @abstractmethod
-    async def _publish_validated(
+    async def _publish_validated(  # noqa: PLR0913
         self,
         *,
         payload: JsonObject,
         type_: Ascii,
         key: Ascii,
         topic: Ascii,
+        event_id: UUID4,
         headers: Mapping[str, str],
     ) -> None:
         """Publish an event with already validated topic and type.
@@ -74,6 +88,7 @@ class EventPublisherProtocol(ABC):
         - `type_` (str): The event type. ASCII characters only.
         - `key` (str): The event type. ASCII characters only.
         - `topic` (str): The event type. ASCII characters only.
+        - `event_id` (UUID): The event ID.
         - `headers`: Additional headers to attach to the event.
         """
         ...

--- a/src/hexkit/protocols/eventsub.py
+++ b/src/hexkit/protocols/eventsub.py
@@ -20,6 +20,8 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from datetime import datetime
 
+from pydantic import UUID4
+
 from hexkit.custom_types import Ascii, JsonObject
 from hexkit.utils import check_ascii
 
@@ -54,6 +56,7 @@ class EventSubscriberProtocol(ABC):
         type_: Ascii,
         topic: Ascii,
         key: Ascii,
+        event_id: UUID4,
     ) -> None:
         """Receive an event of interest and process it according to its type.
 
@@ -62,6 +65,7 @@ class EventSubscriberProtocol(ABC):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
         """
         check_ascii(type_, topic)
 
@@ -69,7 +73,7 @@ class EventSubscriberProtocol(ABC):
             check_ascii(key)
 
         await self._consume_validated(
-            payload=payload, type_=type_, topic=topic, key=key
+            payload=payload, type_=type_, topic=topic, key=key, event_id=event_id
         )
 
     @abstractmethod
@@ -80,6 +84,7 @@ class EventSubscriberProtocol(ABC):
         type_: Ascii,
         topic: Ascii,
         key: Ascii,
+        event_id: UUID4,
     ) -> None:
         """
         Receive and process an event with already validated topic, type, and key.
@@ -89,6 +94,7 @@ class EventSubscriberProtocol(ABC):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
         """
         ...
 
@@ -114,6 +120,7 @@ class DLQSubscriberProtocol(ABC):
         type_: Ascii,
         topic: Ascii,
         key: Ascii,
+        event_id: UUID4,
         timestamp: datetime,
         headers: Mapping[str, str],
     ) -> None:
@@ -124,6 +131,7 @@ class DLQSubscriberProtocol(ABC):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
             timestamp: The timestamp assigned by either the publisher or the broker.
             headers: The event headers containing important metadata.
         """
@@ -137,6 +145,7 @@ class DLQSubscriberProtocol(ABC):
             type_=type_,
             topic=topic,
             key=key,
+            event_id=event_id,
             timestamp=timestamp,
             headers=headers,
         )
@@ -149,6 +158,7 @@ class DLQSubscriberProtocol(ABC):
         type_: Ascii,
         topic: Ascii,
         key: Ascii,
+        event_id: UUID4,
         timestamp: datetime,
         headers: Mapping[str, str],
     ) -> None:
@@ -160,6 +170,7 @@ class DLQSubscriberProtocol(ABC):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
             timestamp: The timestamp assigned by either the publisher or the broker.
             headers: The event headers containing important metadata.
         """

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -198,7 +198,7 @@ class KafkaEventPublisher(EventPublisherProtocol):
                 raise
 
             correlation_id = new_correlation_id()
-            logging.info("Generated new correlation ID: %s", correlation_id)
+            logging.info("Generated new correlation ID: %s.", correlation_id)
 
         # Create a shallow copy of the headers
         headers_copy = dict(headers)
@@ -218,4 +218,11 @@ class KafkaEventPublisher(EventPublisherProtocol):
 
         await self._producer.send_and_wait(
             topic, key=key, value=payload, headers=encoded_headers_list
+        )
+        logging.info(
+            "Published event: topic=%s, type=%s, key=%s, event_id=%s.",
+            topic,
+            type_,
+            key,
+            event_id,
         )

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -45,7 +45,7 @@ from hexkit.providers.akafka.provider.utils import (
     generate_ssl_context,
 )
 
-RESERVED_HEADERS = ["type", "correlation_id"]
+RESERVED_HEADERS = ["type", "correlation_id", "event_id"]
 
 
 class KafkaProducerCompatible(Protocol):

--- a/src/hexkit/providers/akafka/provider/eventpub.py
+++ b/src/hexkit/providers/akafka/provider/eventpub.py
@@ -203,7 +203,6 @@ class KafkaEventPublisher(EventPublisherProtocol):
         # Create a shallow copy of the headers
         headers_copy = dict(headers)  # used for validation and logging only
 
-        # Check and log warnings for reserved headers
         overrides = {
             header: headers_copy[header]
             for header in RESERVED_HEADERS

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -31,12 +31,13 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Literal, Optional, Protocol, TypeVar, Union, cast
+from uuid import UUID, uuid4
 
 from aiokafka import AIOKafkaConsumer
 from opentelemetry import trace
 from opentelemetry.propagate import extract
 from opentelemetry.propagators import textmap
-from pydantic import ValidationError
+from pydantic import UUID4, ValidationError
 
 from hexkit.base import InboundProviderBase
 from hexkit.correlation import correlation_id_from_str, set_correlation_id
@@ -141,7 +142,13 @@ class ComboTranslator(EventSubscriberProtocol):
         self.topics_of_interest.extend(non_outbox_topics)
 
     async def _consume_validated(
-        self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: Ascii
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        topic: Ascii,
+        key: Ascii,
+        event_id: UUID4,
     ) -> None:
         """
         Receive and process an event with already validated topic, type, and key.
@@ -151,6 +158,7 @@ class ComboTranslator(EventSubscriberProtocol):
             type_: The type of the event.
             topic: Name of the topic the event was published to.
             key: A key used for routing the event.
+            event_id: The unique identifier of the event.
         """
         translator = self.translators[topic][type_]
 
@@ -176,7 +184,9 @@ class ComboTranslator(EventSubscriberProtocol):
                 # a deletion event:
                 await translator.deleted(resource_id=key)
         else:
-            await translator.consume(payload=payload, type_=type_, topic=topic, key=key)
+            await translator.consume(
+                payload=payload, type_=type_, topic=topic, key=key, event_id=event_id
+            )
 
 
 class HeaderNames:
@@ -185,8 +195,10 @@ class HeaderNames:
     EVENT_ID = "event_id"
     CORRELATION_ID = "correlation_id"
     ORIGINAL_TOPIC = "original_topic"
+    ORIGINAL_EVENT_ID = "original_event_id"
     EXC_CLASS = "exc_class"
     EXC_MSG = "exc_msg"
+    SERVICE_NAME = "service"
 
 
 class ConsumerEvent(Protocol):
@@ -219,7 +231,8 @@ class ExtractedEventInfo:
     type_: Ascii
     payload: JsonObject
     key: Ascii
-    headers: dict[str, str]
+    event_id: UUID4
+    headers: dict[str, str]  # These are the *remaining* headers
 
     def __init__(self, event: Optional[ConsumerEvent] = None, **kwargs):
         """Initialize an instance of ExtractedEventInfo."""
@@ -229,6 +242,41 @@ class ExtractedEventInfo:
         self.headers = kwargs.get("headers", headers_as_dict(event) if event else {})
         self.headers = cast(dict, self.headers)
         self.type_ = kwargs.get("type_", self.headers.pop("type", ""))
+
+        # Perform some more rigorous checks on the event_id
+        # If event_id is provided as a kwarg (uncommon), it must be a UUID.
+        if event_id := kwargs.get("event_id"):
+            if not isinstance(event_id, UUID):
+                type_error = TypeError(
+                    "Event_id must be a UUID when supplied as a kwarg for"
+                    + f" {self.__class__.__name__}, got {type(event_id).__name__}."
+                )
+                logging.error(type_error)
+                raise type_error
+            self.event_id = event_id
+        else:
+            # If no event_id kwarg is provided (usual case), extract it from the headers
+            event_id_str = self.headers.pop(HeaderNames.EVENT_ID, None)
+            # TODO: Think about whether it makes sense to raise an error here vs log
+            if not event_id_str:
+                # Generate a new UUID if no event_id header is found, but log a warning
+                new_event_id = uuid4()
+                logging.warning(
+                    "No event_id header found in the event. Generated a new one: %s",
+                    new_event_id,
+                )
+                self.event_id = new_event_id
+            else:
+                # Finally, validate the event_id string and convert it to a UUID
+                try:
+                    self.event_id = UUID(event_id_str)
+                except ValueError as err:
+                    value_error = ValueError(
+                        f"Invalid event_id header value: {event_id_str}. "
+                        + "It must be a valid UUID4 string."
+                    )
+                    logging.error(value_error)
+                    raise value_error from err
 
     @property
     def encoded_headers(self) -> list[tuple[str, bytes]]:
@@ -253,11 +301,6 @@ class DLQEventInfo(ExtractedEventInfo):
         )
         self.timestamp = kwargs.pop("timestamp", timestamp)
         super().__init__(event=event, **kwargs)
-
-
-def get_event_id(event: ConsumerEvent, *, service_name: str) -> str:
-    """Make a label that identifies an event."""
-    return f"{service_name},{event.topic},{event.partition},{event.offset}"
 
 
 def headers_as_dict(event: ConsumerEvent) -> dict[str, str]:
@@ -465,31 +508,35 @@ class KafkaEventSubscriber(InboundProviderBase):
         self._enable_dlq = config.kafka_enable_dlq
         self._retry_backoff = config.kafka_retry_backoff
 
-    async def _publish_to_dlq(
-        self, *, event: ExtractedEventInfo, exc: Exception, event_id: str
-    ):
+    async def _publish_to_dlq(self, *, event: ExtractedEventInfo, exc: Exception):
         """Publish the event to the corresponding DLQ topic.
 
         The exception instance is included in the headers, but is split into the class
         name and the string representation of the exception.
 
+        **Note**: A new event ID is generated for the DLQ event, as it is a new event
+        that is being published to the DLQ topic. The original event ID is included
+        in the headers to aid in debugging and tracing the original event that caused
+        the DLQ event to be published.
+
         Args
         - `event`: The event to publish to the DLQ.
         - `exc`: The exception that caused the event to be published to the DLQ.
-        - `event_id`: The service name, topic, partition, and offset of the
-            failed event. Uses the format "service_name,topic,partition,offset".
         """
+        dlq_event_id = uuid4()
         logging.debug("About to publish an event to DLQ topic '%s'", self._dlq_topic)
         await self._dlq_publisher.publish(  # type: ignore
             payload=event.payload,
             type_=event.type_,
             topic=self._dlq_topic,
             key=event.key,
+            event_id=dlq_event_id,
             headers={
                 HeaderNames.EXC_CLASS: exc.__class__.__name__,
                 HeaderNames.EXC_MSG: str(exc),
-                HeaderNames.EVENT_ID: event_id,
                 HeaderNames.ORIGINAL_TOPIC: event.topic,
+                HeaderNames.ORIGINAL_EVENT_ID: str(event.event_id),
+                HeaderNames.SERVICE_NAME: self._service_name,
             },
         )
         logging.info("Published event to DLQ topic '%s'", self._dlq_topic)
@@ -545,7 +592,7 @@ class KafkaEventSubscriber(InboundProviderBase):
             args.pop("headers")
         await self._translator.consume(**args)
 
-    async def _handle_consumption(self, *, event: ExtractedEventInfo, event_id: str):
+    async def _handle_consumption(self, *, event: ExtractedEventInfo):
         """Try to pass the event to the translator.
 
         If the event fails:
@@ -562,18 +609,16 @@ class KafkaEventSubscriber(InboundProviderBase):
             await self._translator_consume(event=event)
         except Exception as underlying_error:
             logging.warning(
-                "Failed initial attempt to consume event of type '%s' on topic '%s' with key '%s'.",
-                event.type_,
+                "Failed initial attempt to consume event. Topic=%s, type=%s, event_id=%s.",
                 event.topic,
-                event.key,
+                event.type_,
+                event.event_id,
             )
 
             if not self._max_retries:
                 if not self._enable_dlq:
                     raise  # re-raise Exception
-                await self._publish_to_dlq(
-                    event=event, exc=underlying_error, event_id=event_id
-                )
+                await self._publish_to_dlq(event=event, exc=underlying_error)
                 return
 
             # Don't raise RetriesExhaustedError unless retries are actually attempted
@@ -586,9 +631,7 @@ class KafkaEventSubscriber(InboundProviderBase):
                 logging.warning(retry_error)
                 if not self._enable_dlq:
                     raise retry_error from underlying_error
-                await self._publish_to_dlq(
-                    event=event, exc=underlying_error, event_id=event_id
-                )
+                await self._publish_to_dlq(event=event, exc=underlying_error)
 
     def _extract_info(self, event: ConsumerEvent) -> ExtractedEventInfo:
         """Convert the raw event to either ExtractedEventInfo or DLQEventInfo.
@@ -643,15 +686,15 @@ class KafkaEventSubscriber(InboundProviderBase):
         with tracer.start_as_current_span(
             name="KafkaEventSubscriber._consume_event", context=extracted_context
         ):
-            event_id = get_event_id(event, service_name=self._service_name)
             event_info = self._extract_info(event)
             try:
                 self._validate_extracted_info(event_info)
             except RuntimeError as err:
                 logging.info(
-                    "Ignored event of type '%s': %s, errors: %s",
+                    "Ignored event. Topic=%s, type=%s, event_id=%s, errors: %s",
+                    event.topic,  # use actual topic, not event_info.topic
                     event_info.type_,
-                    event_id,
+                    event_info.event_id,
                     str(err),
                 )
                 # Always acknowledge event receipt for ignored events
@@ -660,19 +703,22 @@ class KafkaEventSubscriber(InboundProviderBase):
 
             try:
                 logging.info(
-                    "Consuming event of type '%s': %s", event_info.type_, event_id
+                    "Consuming event of type '%s': %s",
+                    event_info.type_,
+                    event_info.event_id,
                 )
                 correlation_id = event_info.headers[HeaderNames.CORRELATION_ID]
                 async with set_correlation_id(correlation_id_from_str(correlation_id)):
-                    await self._handle_consumption(event=event_info, event_id=event_id)
+                    await self._handle_consumption(event=event_info)
             except Exception:
                 # Errors only bubble up here if the DLQ isn't used
                 logging.critical(
-                    "An error occurred while processing event of type '%s': %s. It was NOT"
-                    " placed in the DLQ topic (%s)",
-                    event_info.type_,
-                    event_id,
+                    "Failed to process event. It was NOT placed in the DLQ topic (%s)."
+                    + " Topic=%s, type=%s, event_id=%s.",
                     self._dlq_topic if self._enable_dlq else "DLQ is disabled",
+                    event_info.topic,
+                    event_info.type_,
+                    event_info.event_id,
                 )
                 raise
             else:

--- a/src/hexkit/providers/akafka/provider/eventsub.py
+++ b/src/hexkit/providers/akafka/provider/eventsub.py
@@ -243,28 +243,20 @@ class ExtractedEventInfo:
         self.headers = cast(dict, self.headers)
         self.type_ = kwargs.get("type_", self.headers.pop("type", ""))
 
-        # Perform some more rigorous checks on the event_id
-        # If event_id is provided as a kwarg (uncommon), it must be a UUID.
-        if event_id := kwargs.get("event_id"):
-            if not isinstance(event_id, UUID):
-                type_error = TypeError(
-                    "Event_id must be a UUID when supplied as a kwarg for"
-                    + f" {self.__class__.__name__}, got {type(event_id).__name__}."
-                )
-                logging.error(type_error)
-                raise type_error
+        # Retrieve the event ID from the headers or kwargs.
+        event_id = kwargs.get("event_id", self.headers.pop(HeaderNames.EVENT_ID, ""))
+        if isinstance(event_id, UUID):
+            # If it is a UUID, use it directly
             self.event_id = event_id
         else:
-            # If no event_id kwarg is provided (usual case), extract it from the headers
-            event_id_str = self.headers.pop(HeaderNames.EVENT_ID, "")
             try:
-                self.event_id = UUID(event_id_str)
+                self.event_id = UUID(event_id)
             except ValueError:
                 # Generate a new UUID, but log a warning including the encountered value
                 new_event_id = uuid4()
                 found_val = (
-                    f"Invalid event_id encountered: {event_id_str}"
-                    if event_id_str
+                    f"Invalid event_id encountered: {event_id}"
+                    if event_id
                     else "No event_id header found"
                 )
 

--- a/src/hexkit/providers/akafka/testutils.py
+++ b/src/hexkit/providers/akafka/testutils.py
@@ -39,6 +39,7 @@ import pytest
 import pytest_asyncio
 from aiokafka import AIOKafkaConsumer, TopicPartition
 from aiokafka.admin import AIOKafkaAdminClient, RecordsToDelete
+from pydantic import UUID4
 from testcontainers.kafka import KafkaContainer
 
 from hexkit.custom_types import Ascii, JsonObject, PytestScope
@@ -83,14 +84,15 @@ class EventBase:
 class ExpectedEvent(EventBase):
     """Used to describe events expected in a specific topic using an EventRecorder.
 
-    Please note, the key type is optional. If it is set to `None` (the default), the
-    event key will be ignored when compared to the recording.
-
-    The `headers` value is treated the same as `key` -- it is ignored in comparison if
-    it is set to `None`.
+    The core fields -- `payload` and `type_` -- are required.
+    The fields defined here -- `key`, `event_id`, and `headers` -- are optional.
+    The optional fields are only compared against the recorded events if they are set to
+    some value other than `None`. If they are set to `None`, they will be ignored
+    when comparing the expected event to the recorded event.
     """
 
     key: Optional[Ascii] = None
+    event_id: Optional[Ascii] = None
     headers: Optional[dict[str, str]] = None
 
 
@@ -98,12 +100,13 @@ class ExpectedEvent(EventBase):
 class RecordedEvent(EventBase):
     """Used by the EventRecorder class to describe events recorded in a specific topic.
 
-    The event type information is stored in the header but extracted into its own field
-    because of its importance for the comparison. Because of this, it is also removed
-    from the headers.
+    The event type and event ID are stored in the header but extracted into their own
+    fields because of their importance for comparison. Because of this, they're also
+    removed from the headers.
     """
 
     key: Ascii
+    event_id: Ascii
     headers: Optional[dict[str, str]] = None
 
 
@@ -175,6 +178,11 @@ def check_recorded_events(
             raise get_field_mismatch_error(field="type", index=index)
         if expected_event.key is not None and recorded_event.key != expected_event.key:
             raise get_field_mismatch_error(field="key", index=index)
+        if (
+            expected_event.event_id is not None
+            and recorded_event.event_id != expected_event.event_id
+        ):
+            raise get_field_mismatch_error(field="event_id", index=index)
         if (
             expected_event.headers is not None
             and recorded_event.headers != expected_event.headers
@@ -337,16 +345,21 @@ class EventRecorder:
         ]
 
         recorded_events: list[RecordedEvent] = []
+
+        # TODO: should I delete event ID from the headers, like with the type?
         for raw_event in raw_events:
             headers = headers_as_dict(raw_event)
             type_ = headers.get("type", "")
+            event_id = headers.get("event_id", "")
             del headers["type"]
+            del headers["event_id"]
 
             recorded_event = RecordedEvent(
                 payload=raw_event.value,
                 type_=type_,
                 key=raw_event.key,
                 headers=headers if self._capture_headers else None,
+                event_id=event_id,
             )
             recorded_events.append(recorded_event)
         return recorded_events
@@ -416,18 +429,24 @@ class KafkaFixture:
         self.publisher = publisher
         self.admin_client: Optional[AIOKafkaAdminClient] = None
 
-    async def publish_event(
+    async def publish_event(  # noqa: PLR0913
         self,
         *,
         payload: JsonObject,
         type_: Ascii,
         topic: Ascii,
         key: Ascii = "test",
+        event_id: Optional[UUID4] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """A convenience method to publish a test event."""
         await self.publisher.publish(
-            payload=payload, type_=type_, key=key, topic=topic, headers=headers
+            payload=payload,
+            type_=type_,
+            key=key,
+            topic=topic,
+            event_id=event_id,
+            headers=headers,
         )
 
     def record_events(

--- a/src/hexkit/providers/akafka/testutils.py
+++ b/src/hexkit/providers/akafka/testutils.py
@@ -346,7 +346,6 @@ class EventRecorder:
 
         recorded_events: list[RecordedEvent] = []
 
-        # TODO: should I delete event ID from the headers, like with the type?
         for raw_event in raw_events:
             headers = headers_as_dict(raw_event)
             type_ = headers.get("type", "")

--- a/src/hexkit/providers/mongokafka/provider/persistent_pub.py
+++ b/src/hexkit/providers/mongokafka/provider/persistent_pub.py
@@ -65,8 +65,8 @@ class PersistentKafkaEvent(BaseModel):
     event_id: Optional[UUID4] = Field(default=None, description="The event ID")
     headers: Mapping[str, str] = Field(
         default_factory=dict,
-        description="Event ID and other event headers. Correlation ID and event type are"
-        + " transmitted as event headers, but added as such within the publisher"
+        description="Non-standard event headers. Correlation ID, event_id, and event"
+        + " type are transmitted as event headers, but added as such within the publisher"
         + " protocol. The headers here are any additional header that need to be sent.",
     )
     correlation_id: UUID4 = UUID4Field(description="The event correlation ID")
@@ -253,11 +253,9 @@ class PersistentKafkaPublisher(EventPublisherProtocol):
         events.sort(key=lambda x: x.created)
 
         for event in events:
-            # If there's no event ID, generate a new UUID. It will get stored when the
-            # event is published. Set `published` to `False` to trigger an update.
+            # If there's no event ID, generate a new UUID.
             if not event.event_id:
                 event.event_id = uuid4()
-                event.published = False
             await self._publish_and_update(event)
 
     async def republish(self) -> None:

--- a/src/hexkit/providers/testing/eventpub.py
+++ b/src/hexkit/providers/testing/eventpub.py
@@ -23,6 +23,7 @@ ATTENTION: For testing purposes only.
 from collections import defaultdict, deque
 from collections.abc import Mapping
 from typing import NamedTuple, Optional
+from uuid import UUID
 
 from hexkit.custom_types import JsonObject
 from hexkit.protocols.eventpub import EventPublisherProtocol
@@ -77,13 +78,14 @@ class InMemEventPublisher(EventPublisherProtocol):
         """Initialize with existing event_store or let it create a new one."""
         self.event_store = event_store if event_store else InMemEventStore()
 
-    async def _publish_validated(
+    async def _publish_validated(  # noqa: PLR0913
         self,
         *,
         payload: JsonObject,
         type_: str,
         key: str,
         topic: str,
+        event_id: UUID,
         headers: Mapping[str, str],
     ) -> None:
         """Publish an event with already validated topic and type.

--- a/tests/integration/akafka/test_akafka.py
+++ b/tests/integration/akafka/test_akafka.py
@@ -21,7 +21,7 @@ from contextlib import nullcontext
 from datetime import date, datetime, timezone
 from os import environ
 from pathlib import Path
-from typing import Optional, cast
+from typing import Optional, Union, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -477,7 +477,7 @@ async def test_publish_with_event_id_header(kafka: KafkaFixture, caplog):
     ids=["None", "InvalidHeader", "EmptyString"],
 )
 async def test_invalid_or_missing_event_id_header(
-    kafka: KafkaFixture, caplog, event_id_header: str | None, log_msg: str
+    kafka: KafkaFixture, caplog, event_id_header: Union[str, None], log_msg: str
 ):
     """Test that when consuming an event with an invalid or missing event ID header,
     a new value is generated and a warning is logged.

--- a/tests/integration/akafka/test_akafka.py
+++ b/tests/integration/akafka/test_akafka.py
@@ -21,7 +21,7 @@ from contextlib import nullcontext
 from datetime import date, datetime, timezone
 from os import environ
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import Optional, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -412,7 +412,7 @@ async def test_publish_event_id_conflict(kafka: KafkaFixture, caplog):
     header_event_id = uuid.uuid4()
     assert kw_event_id != header_event_id
 
-    # Publish the first event
+    # Publish the event
     async with kafka.record_events(in_topic=topic) as recorder:
         await kafka.publish_event(
             payload={"test_content": "First Event"},
@@ -427,7 +427,8 @@ async def test_publish_event_id_conflict(kafka: KafkaFixture, caplog):
 
     assert_logged(
         level="WARNING",
-        message="The 'event_id' header shouldn't be supplied, but was. Overwriting.",
+        message="The 'event_id' header shouldn't be supplied, but was. Overwriting"
+        + f" old value ({header_event_id}) with {kw_event_id}.",
         records=caplog.records,
         parse=True,
     )
@@ -461,7 +462,8 @@ async def test_publish_with_event_id_header(kafka: KafkaFixture, caplog):
 
     assert_logged(
         level="WARNING",
-        message="The 'event_id' header shouldn't be supplied, but was. Overwriting.",
+        message="The 'event_id' header shouldn't be supplied, but was. Overwriting"
+        + f" old value ({event_id}) with {recorder.recorded_events[0].event_id}.",
         records=caplog.records,
         parse=True,
     )
@@ -477,7 +479,7 @@ async def test_publish_with_event_id_header(kafka: KafkaFixture, caplog):
     ids=["None", "InvalidHeader", "EmptyString"],
 )
 async def test_invalid_or_missing_event_id_header(
-    kafka: KafkaFixture, caplog, event_id_header: Union[str, None], log_msg: str
+    kafka: KafkaFixture, caplog, event_id_header: Optional[str], log_msg: str
 ):
     """Test that when consuming an event with an invalid or missing event ID header,
     a new value is generated and a warning is logged.

--- a/tests/integration/akafka/test_akafka_testutils.py
+++ b/tests/integration/akafka/test_akafka_testutils.py
@@ -25,6 +25,7 @@ from uuid import UUID
 import pytest
 from aiokafka import AIOKafkaConsumer
 from aiokafka.structs import TopicPartition
+from pydantic import UUID4
 
 from hexkit.correlation import set_correlation_id
 from hexkit.custom_types import Ascii, JsonObject
@@ -53,6 +54,7 @@ TEST_TYPE = "test_type"
 TEST_TOPIC1 = "topic1"
 TEST_TOPIC2 = "topic2"
 TEST_TOPICS = [TEST_TOPIC1, TEST_TOPIC2]
+TEST_EVENT_ID = "f8b1c0d2-3e4f-4a5b-8c6d-7e8f9a0b1c2d"
 
 
 def make_payload(msg: str) -> JsonObject:
@@ -71,7 +73,13 @@ class DummyTranslator(EventSubscriberProtocol):
         }
 
     async def _consume_validated(
-        self, *, payload: JsonObject, type_: Ascii, topic: Ascii, key: Ascii
+        self,
+        *,
+        payload: JsonObject,
+        type_: Ascii,
+        topic: Ascii,
+        key: Ascii,
+        event_id: UUID4,
     ):
         self.consumed[topic].append(payload)
 
@@ -227,11 +235,13 @@ async def test_clear_all_topics(kafka: KafkaFixture):
                     payload={"test_content": "Hello"},
                     type_="test_hello",
                     key="test_key",
+                    event_id=TEST_EVENT_ID,
                 ),
                 RecordedEvent(
                     payload={"test_content": "World"},
                     type_="test_world",
                     key="test_key",
+                    event_id=TEST_EVENT_ID,
                 ),
             ],
             False,
@@ -242,12 +252,14 @@ async def test_clear_all_topics(kafka: KafkaFixture):
                     payload={"test_content": "Hello"},
                     type_="test_hello",
                     key="test_key",
+                    event_id=TEST_EVENT_ID,
                     headers={"correlation_id": str(DEFAULT_CORRELATION_ID)},
                 ),
                 RecordedEvent(
                     payload={"test_content": "World"},
                     type_="test_world",
                     key="test_key",
+                    event_id=TEST_EVENT_ID,
                     headers={"correlation_id": str(DEFAULT_CORRELATION_ID)},
                 ),
             ],
@@ -281,6 +293,7 @@ async def test_event_recorder(
                 payload=event.payload,
                 type_=event.type_,
                 key=event.key,
+                event_id=UUID(event.event_id),
                 topic=topic,
             )
 
@@ -336,11 +349,13 @@ async def test_expect_events_happy(kafka: KafkaFixture):
             payload={"test_content": "Hello"},
             type_="test_hello",
             key="test_key",
+            event_id=TEST_EVENT_ID,
         ),
         RecordedEvent(
             payload={"test_content": "World"},
             type_="test_world",
             key="test_key",
+            event_id=TEST_EVENT_ID,
         ),
     ]
     topic = "test_topic"
@@ -370,57 +385,91 @@ async def test_expect_events_happy(kafka: KafkaFixture):
         # event payload wrong:
         [
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="test_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
-                payload={"test_content": "Wörld"}, type_="test_world", key="test_key"
+                payload={"test_content": "Wörld"},
+                type_="test_world",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
         # event type wrong:
         [
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="test_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
-                payload={"test_content": "World"}, type_="test_woerld", key="test_key"
+                payload={"test_content": "World"},
+                type_="test_woerld",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
         # event key wrong:
         [
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="wrong_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="wrong_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
-                payload={"test_content": "World"}, type_="test_world", key="wrong_key"
+                payload={"test_content": "World"},
+                type_="test_world",
+                key="wrong_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
         # one event missing:
         [
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="test_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
         # one event too much:
         [
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="test_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
-                payload={"test_content": "World"}, type_="test_world", key="test_key"
+                payload={"test_content": "World"},
+                type_="test_world",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
                 payload={"test_content": "unexpected"},
                 type_="test_unexpected",
                 key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
         # wrong sequence:
         [
             RecordedEvent(
-                payload={"test_content": "World"}, type_="test_world", key="test_key"
+                payload={"test_content": "World"},
+                type_="test_world",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
             RecordedEvent(
-                payload={"test_content": "Hello"}, type_="test_hello", key="test_key"
+                payload={"test_content": "Hello"},
+                type_="test_hello",
+                key="test_key",
+                event_id=TEST_EVENT_ID,
             ),
         ],
     ],

--- a/tests/integration/akafka/test_persistent_pub.py
+++ b/tests/integration/akafka/test_persistent_pub.py
@@ -49,6 +49,7 @@ TEST_TYPE = "my_type"
 TEST_PAYLOAD = {"some": "payload"}
 TEST_KEY = "somekey123"
 TEST_CORRELATION_ID = UUID("9ef5956f-be9c-427a-ab4a-42ae1e231c86")
+TEST_EVENT_ID = UUID("40a7a7c5-1e2f-4a1f-b053-cf918edd1b40")
 
 
 async def test_basic_publish(kafka: KafkaFixture, mongodb: MongoDbFixture):
@@ -66,11 +67,13 @@ async def test_basic_publish(kafka: KafkaFixture, mongodb: MongoDbFixture):
     dao_factory = MongoDbDaoFactory(config=config)
 
     expected_db_event = {
+        "compaction_key": str(TEST_EVENT_ID),  # this field is str-typed
         "topic": TEST_TOPIC,
         "type_": TEST_TYPE,
         "payload": TEST_PAYLOAD,
         "key": TEST_KEY,
         "headers": {},
+        "event_id": TEST_EVENT_ID,
         "correlation_id": TEST_CORRELATION_ID,
         "published": True,
     }
@@ -95,6 +98,7 @@ async def test_basic_publish(kafka: KafkaFixture, mongodb: MongoDbFixture):
             topic=TEST_TOPIC,
             type_=TEST_TYPE,
             key=TEST_KEY,
+            event_id=TEST_EVENT_ID,
             headers=None,
         )
     # Inspect & verify some expectations about the event that we published
@@ -113,15 +117,13 @@ async def test_basic_publish(kafka: KafkaFixture, mongodb: MongoDbFixture):
 
     # Convert to model and dump as dict
     dto_dict = document_to_dto(
-        stored_event_doc, id_field="id", dto_model=PersistentKafkaEvent
+        stored_event_doc, id_field="compaction_key", dto_model=PersistentKafkaEvent
     ).model_dump()
 
     # Inspect the 'created' and 'id' fields
     timestamp = dto_dict.pop("created")
     assert datetime.now(tz=timezone.utc) - timestamp <= timedelta(seconds=30)
 
-    # Verify that the ID is a valid UUID (no error means it's valid)
-    UUID(dto_dict.pop("id"))
     assert dto_dict == expected_db_event
 
 
@@ -158,6 +160,7 @@ async def test_republish(kafka: KafkaFixture, mongodb: MongoDbFixture):
                 headers=None,
             )
 
+    assert len(recorder1.recorded_events) == 3
     docs = collection.find().to_list()
     assert len(docs) == 3
 
@@ -365,3 +368,69 @@ async def test_conflicting_args():
         + " Please review the following values: conflict1, conflict2."
     )
     assert err.value.args[0] == msg
+
+
+@pytest.mark.parametrize("method", ["republish", "publish_pending"])
+@pytest.mark.parametrize(
+    "set_event_id",
+    [True, False],
+    ids=["EventIdSet", "EventIdNotSet"],
+)
+async def test_republish_with_event_id_presence(
+    kafka: KafkaFixture, mongodb: MongoDbFixture, method: str, set_event_id: bool
+):
+    """Test that `republish`/`publish_pending` uses the event_id from the database.
+    Alternatively, if the event_id is not set, it should generate a new one.
+    """
+    config = MongoKafkaConfig(
+        **kafka.config.model_dump(), **mongodb.config.model_dump()
+    )
+    collection_name = f"{config.service_name}PersistedEvents"
+    dao_factory = MongoDbDaoFactory(config=config)
+
+    # Insert an event manually in the database, marked as unpublished
+    collection = mongodb.client[config.db_name][collection_name]
+    event = {
+        "_id": f"{TEST_TOPIC}:{TEST_KEY}",
+        "topic": TEST_TOPIC,
+        "type_": TEST_TYPE,
+        "key": TEST_KEY,
+        "payload": {"new": "payload"},
+        "headers": {},
+        "correlation_id": TEST_CORRELATION_ID,
+        "created": now_utc_ms_prec(),
+        "published": False,
+        "event_id": TEST_EVENT_ID if set_event_id else None,
+    }
+    collection.insert_one(event)
+
+    # Publish pending events
+    async with (
+        PersistentKafkaPublisher.construct(
+            config=config,
+            dao_factory=dao_factory,
+            collection_name=collection_name,
+        ) as persistent_publisher,
+        kafka.record_events(in_topic=TEST_TOPIC, capture_headers=True) as recorder,
+        set_correlation_id(TEST_CORRELATION_ID),
+    ):
+        method_to_await = getattr(persistent_publisher, method)
+        await method_to_await()
+
+    # Verify that the event was published with the correct event_id
+    assert len(recorder.recorded_events) == 1
+
+    recorded_event_id = recorder.recorded_events[0].event_id
+    if not set_event_id:
+        # If set_event_id is False, a new event_id should be generated
+        assert recorded_event_id != str(TEST_EVENT_ID)
+        # The event_id should be a valid UUID
+        assert UUID(recorded_event_id)
+
+        # Check that the event_id in the DB is also updated
+        db_events = collection.find().to_list()
+        assert len(db_events) == 1
+        assert db_events[0]["event_id"] == UUID(recorded_event_id)
+    else:
+        # If set_event_id is True, the event_id should match the one in the DB
+        assert recorded_event_id == str(TEST_EVENT_ID)

--- a/tests/integration/akafka/test_translators.py
+++ b/tests/integration/akafka/test_translators.py
@@ -108,7 +108,7 @@ class DummyEventSubTranslator(EventSubscriberProtocol):
         self.consumed: list[tuple[dict, Ascii, Ascii, Ascii]] = []
 
     async def _consume_validated(  # type: ignore
-        self, *, payload: dict, type_: Ascii, topic: Ascii, key: Ascii
+        self, *, payload: dict, type_: Ascii, topic: Ascii, key: Ascii, event_id: str
     ) -> None:
         self.consumed.append((payload, type_, topic, key))
 

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -276,6 +276,7 @@ async def test_correlation_consuming(
             type_: Ascii,
             topic: Ascii,
             key: Ascii,
+            event_id: UUID4,
         ) -> None:
             # Make sure the IDs match
             if not cid_in_header:

--- a/tests/unit/test_akafka.py
+++ b/tests/unit/test_akafka.py
@@ -19,7 +19,7 @@
 from collections import namedtuple
 from contextlib import nullcontext
 from typing import Optional
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock
 from uuid import UUID
 
 import pytest
@@ -47,8 +47,10 @@ async def test_kafka_event_publisher():
     key = "test_key"
     topic = "test_topic"
     payload = {"test_content": "Hello World"}
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
     expected_headers = [
         ("type", b"test_type"),
+        ("event_id", b"12345678-1234-5678-1234-567812345678"),
         CORRELATION_ID_HEADER,
     ]
 
@@ -82,6 +84,7 @@ async def test_kafka_event_publisher():
                 type_=type_,
                 key=key,
                 topic=topic,
+                event_id=event_id,
             )
 
     # check if producer was correctly used:
@@ -208,7 +211,7 @@ async def test_kafka_event_subscriber(
     # check if the translator was called correctly:
     if is_translator_called:
         translator.consume.assert_awaited_once_with(
-            payload=payload, type_=type_, topic=topic, key=event.key
+            payload=payload, type_=type_, topic=topic, key=event.key, event_id=ANY
         )
     else:
         assert translator.consume.await_count == 0

--- a/tests/unit/test_eventpub.py
+++ b/tests/unit/test_eventpub.py
@@ -31,7 +31,9 @@ class FakePublisher(EventPublisherProtocol):
     any logic.
     """
 
-    async def _publish_validated(self, *, payload, type_, key, topic, headers) -> None:
+    async def _publish_validated(
+        self, *, payload, type_, key, topic, event_id, headers
+    ) -> None:
         pass
 
 

--- a/tests/unit/test_eventsub.py
+++ b/tests/unit/test_eventsub.py
@@ -18,6 +18,7 @@
 
 from contextlib import nullcontext
 from typing import Optional
+from uuid import UUID
 
 import pytest
 
@@ -31,7 +32,7 @@ class FakeSubscriber(EventSubscriberProtocol):
     any logic.
     """
 
-    async def _consume_validated(self, *, payload, type_, topic, key) -> None:
+    async def _consume_validated(self, *, payload, type_, topic, key, event_id) -> None:
         pass
 
 
@@ -68,9 +69,10 @@ async def test_ascii_val(
 
     # create event publisher:
     event_submitter = FakeSubscriber()
+    test_uuid = UUID("123e4567-e89b-12d3-a456-426614174000")
 
     # publish event using the provider:
     with pytest.raises(exception) if exception else nullcontext():
         await event_submitter.consume(
-            payload=payload, type_=type_, topic=topic, key=key
+            payload=payload, type_=type_, topic=topic, key=key, event_id=test_uuid
         )


### PR DESCRIPTION
# TL;DR
This work is for [Eurasian Blackbird epic spec](https://github.com/ghga-de/epic-docs/blob/main/75-eurasian-blackbird/technical_specification.md).
Events now have a new event_id header. You can supply your own or let it get autogenerated.
If sent to DLQ, a new event ID is created for that and the old one goes into the headers under `original_event_id`.

| Provider                 | Supply Custom Event ID? | Stores Event ID? | Reuses Event ID in Repub? |
|--------------------------|-------------------------|------------------|---------------------------|
| KafkaEventPublisher      | ✅                      | ❌               | --                        |
| MongoKafkaDaoPublisher   | ❌                      | ✅               | ❌                        |
| PersistentKafkaPublisher | ✅                      | ✅               | ✅                        |

# Changes In-Depth

Hexkit now publishes every Kafka event with a UUID4 header field named `event_id`.
No error is raised when consuming a Kafka event with a missing/invalid event ID header, so
this won't cause problems when consuming already-existing Kafka events.

### Protocol Updates
`EventPublisherProtocol` (Used by the `KafkaEventPublisher` and `PersistentKafkaPublisher`)
- Accepts _optional_ `event_id` parameter (UUID)

`EventSubscriberProtocol` (Used by service-defined event translators, not by `KafkaEventSubscriber`)
- _Requires_ the `event_id` parameter (UUID)

`DaoSubscriberProtocol` and `DaoPublisherFactoryProtocol` (used by the outbox publisher) _have not changed_.

### Behavior of Event Pub Providers
There are 3 non-test publishing providers in hexkit that emit Kafka events:
- `KafkaEventPublisher`
- `MongoKafkaDaoPublisher`
- `PersistentKafkaPublisher`

#### KafkaEventPublisher:
The `KafkaEventPublisher` provider is the main event publishing provider in `hexkit`.
- You _can_ supply pre-generated event IDs via the `event_id` parameter.
- You _cannot_ supply an event ID via the `headers` parameter. If you do, it will be overwritten by a randomly generated UUID4.
<img width="570" height="940" alt="image" src="https://github.com/user-attachments/assets/0ec25c7c-7297-4121-93bd-6082cb9945dd" />


#### MongoKafkaDaoPublisher:
This provider is the "outbox" publishing provider, which translates the latest state of DB-stored domain objects into Kafka events.
As discussed in the epic spec,
when the outbox provider publishes an event, it updates the corresponding DB document with the most recent event ID (stored as `last_event_id`).
- The outbox publisher does not reuse `last_event_id` during republish.
- You _cannot_ use pre-generated event IDs when using the outbox publisher.

<img width="583" height="435" alt="image" src="https://github.com/user-attachments/assets/eb44e943-e4ff-4510-84f3-bc1180296bcc" />


#### PersistentKafkaPublisher:
This provider is used to keep a local copy of published events, including each event's event ID.
- You _can_ supply pre-generated event IDs via the `event_id` parameter.
- You _cannot_ supply an event ID via the `headers` parameter. If you do, it will be overwritten by a randomly generated UUID4.
- During republish, it will publish a given stored event using the stored ID.
- In the database, the document's `_id` is `f"{topic}:{key}"` if the topic is compacted. If not compacted, `_id` is the same as `event_id`. 
<img width="627" height="435" alt="image" src="https://github.com/user-attachments/assets/e5572a42-0fb0-4f06-9e48-a47da7088c2c" />



### Behavior of Event Sub Providers

#### KafkaEventSubscriber
The helper class, `ExtractedEventInfo` does the heavy lifting. After it gets the other event data (type, topic, key, etc.), it will try to extract `event_id`.
- If the event ID is present in the headers as well as the kwargs, the kwarg takes precedence.
- If the event ID is already a valid UUID, we use that.
- If the event ID is not a valid UUID, we will try to cast it to a UUID. If that works, we use it.
- If the event ID fails to be cast to a UUID or is missing, we will generate a new event UUID4 and log a warning.
<img width="881" height="552" alt="image" src="https://github.com/user-attachments/assets/899d9799-f64a-481e-bec5-aa3b0e1b5c38" />


  
#### KafkaOutboxSubscriber
The `KafkaOutboxSubscriber` just wraps the `KafkaEventSubscriber`. No specific changes.


### Kafka Logging Conventions
I updated the log statements to be more readable. They now include the topic, type, key, and event_id, in that order (general to specific).

## Testing
- `RecordedEvent` instances now require `event_id` as an `Ascii` value.
- `ExpectedEvent` instances take `event_id` but don't require it.
- When using the `expect_events()` test util, `event_id` is only tested if you specify it in the expected events.
- I made sure to cover...:
  - Consuming invalid/missing event ID headers
  - Outbox publisher updates the `last_event_id` on both upsert and delete
  - Happy path random event ID
  - Happy path pre-generated event ID
  - In DLQ path, original event ID is placed in header and a new dlq event ID is generated (when sent to dlq topic, not when consumed from it)
  - Supplying event_id as both kwarg and header value simultaneously on publish
  - Supplying event_id only through the headers on publish (should be ignored/overwritten)

## Adapting Services

Services will need the following changes for this PR:
- Migrate all Persistent Event data to include event ID as a UUID4 field. If the event is from a *non-compacted* topic, then populate `event_id` with the UUID value from `_id`, otherwise generate a new one.
- Migrate DLQ events in the DLQ service by deleting `dlq_info.partition` & `dlq_info.offset` and adding a randomly generated UUID4 value for `dlq_info.original_event_id`
- Translator class definitions need the new `event_id` parameter, and all invocations need to be adapted.
- Update the DLQS: `DLQInfo` (class) and `stored_event_from_raw_event()` (function) need to change.