### PR TITLE
Helper functions for hexkit v6 migrations (GSI-1730)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "5.4.0"
+version = "6.0.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.9"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "5.4.0"
+version = "6.0.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.31.1, <2",

--- a/src/hexkit/providers/mongodb/migrations/helpers.py
+++ b/src/hexkit/providers/mongodb/migrations/helpers.py
@@ -21,6 +21,7 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from hexkit.providers.mongodb.migrations import Document
+from hexkit.utils import round_datetime_to_ms
 
 __all__ = [
     "convert_outbox_correlation_id_v6",
@@ -53,12 +54,7 @@ def convert_uuids_and_datetimes_v6(
             old_dt = datetime.fromisoformat(doc[field])
             if old_dt.tzname() != "UTC":
                 old_dt = old_dt.astimezone(timezone.utc)
-            microseconds = old_dt.microsecond
-
-            # Round to milliseconds and account for case where microseconds are >999500
-            rounded_ms = (round(microseconds / 1000) % 1000) * 1000
-            new_dt = old_dt.replace(microsecond=rounded_ms)
-            doc[field] = new_dt
+            doc[field] = round_datetime_to_ms(old_dt)
         return doc
 
     return convert

--- a/src/hexkit/providers/mongodb/migrations/helpers.py
+++ b/src/hexkit/providers/mongodb/migrations/helpers.py
@@ -1,0 +1,91 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prefab functions to help with migrations caused by changes in Hexkit."""
+
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from hexkit.providers.mongodb.migrations import Document
+
+__all__ = [
+    "convert_outbox_correlation_id_v6",
+    "convert_persistent_event_v6",
+    "convert_uuids_and_datetimes_v6",
+]
+
+
+def convert_uuids_and_datetimes_v6(
+    *,
+    uuid_fields: Optional[list[str]] = None,
+    date_fields: Optional[list[str]] = None,
+) -> Callable[[Document], Awaitable[Document]]:
+    """Produce a function to convert a document to the format expected by Hexkit v6.
+
+    Args:
+        uuid_fields: List of fields currently storing UUIDs in string format.
+        date_fields: List of fields currently storing datetimes as isoformat strings.
+    """
+
+    async def convert(doc: Document) -> Document:
+        """Convert the document."""
+        for field in uuid_fields or []:
+            doc[field] = UUID(doc[field])
+        for field in date_fields or []:
+            old_dt = datetime.fromisoformat(doc[field])
+            new_dt = old_dt.replace(microsecond=old_dt.microsecond // 1000 * 1000)
+            doc[field] = new_dt
+        return doc
+
+    return convert
+
+
+async def convert_outbox_correlation_id_v6(doc: Document) -> Document:
+    """Convert an outbox document's correlation ID to the format expected by Hexkit v6.
+
+    This will only convert the __metadata__.correlation_id to a UUID.
+
+    If you need to modify other fields, you must define that logic separately.
+    """
+    if correlation_id_str := doc.get("__metadata__", {}).get("correlation_id", ""):
+        doc["__metadata__"]["correlation_id"] = UUID(correlation_id_str)
+    return doc
+
+
+_convert_persistent_event_existing_fields_v6 = convert_uuids_and_datetimes_v6(
+    uuid_fields=["correlation_id"], date_fields=["created"]
+)
+
+
+async def convert_persistent_event_v6(doc: Document) -> Document:
+    """Convert a persistent event document to the format expected by Hexkit v6.
+
+    This will:
+    - convert correlation_id to UUID
+    - convert created to UTC datetime with milliseconds precision
+    - populate event_id with UUID
+
+    If you need to modify other fields, you must define that logic separately.
+    """
+    doc = await _convert_persistent_event_existing_fields_v6(doc)
+    try:
+        # Attempt to convert the _id field to a UUID, since it is either a random
+        # UUID string or a non-UUID string in form "topic:key".
+        doc["event_id"] = UUID(doc["_id"])
+    except ValueError:
+        doc["event_id"] = uuid4()  # Fallback to a new UUID if conversion fails
+    return doc

--- a/src/hexkit/providers/mongodb/migrations/helpers.py
+++ b/src/hexkit/providers/mongodb/migrations/helpers.py
@@ -16,7 +16,7 @@
 """Prefab functions to help with migrations caused by changes in Hexkit."""
 
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -47,6 +47,8 @@ def convert_uuids_and_datetimes_v6(
             doc[field] = UUID(doc[field])
         for field in date_fields or []:
             old_dt = datetime.fromisoformat(doc[field])
+            if old_dt.tzname() != "UTC":
+                old_dt = old_dt.astimezone(timezone.utc)
             new_dt = old_dt.replace(microsecond=old_dt.microsecond // 1000 * 1000)
             doc[field] = new_dt
         return doc

--- a/src/hexkit/utils.py
+++ b/src/hexkit/utils.py
@@ -128,10 +128,12 @@ async def set_context_var(context_var: ContextVar, value: Any):
 
 
 def now_utc_ms_prec() -> datetime:
-    """Return the current UTC time without microseconds.
+    """Return the current UTC time with microseconds rounded to milliseconds.
 
     This is useful for producing a datetime that is consistent
     with MongoDB's millisecond precision.
     """
     current_time = datetime.now(timezone.utc)
-    return current_time.replace(microsecond=current_time.microsecond // 1000 * 1000)
+    # Round microseconds to milliseconds
+    rounded_ms = (round(current_time.microsecond / 1000) % 1000) * 1000
+    return current_time.replace(microsecond=rounded_ms)

--- a/src/hexkit/utils.py
+++ b/src/hexkit/utils.py
@@ -137,8 +137,7 @@ def round_datetime_to_ms(dt: datetime) -> datetime:
     # Calculate the delta to add or subtract to round to the nearest millisecond.
     # we subtract sub_ms either from 1000 if rounding up or from 0 if rounding down
     delta = timedelta(microseconds=(1000 * (sub_ms >= 500)) - sub_ms)
-    new_dt = dt + delta
-    return new_dt
+    return dt + delta
 
 
 def now_utc_ms_prec() -> datetime:

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -177,9 +177,8 @@ def test_validate_doc():
             datetime(2023, 10, 1, 12, 34, 56, 1001),
             datetime(2023, 10, 1, 12, 34, 56, 1000),
         ),
-        (datetime(2023, 1, 1, 1, 1, 1, 171500), datetime(2023, 1, 1, 1, 1, 1, 172000)),
     ],
-    ids=["EndOfYear", "RoundDown", "NoRound", "SmallMicroseconds", "RoundUp"],
+    ids=["EndOfYear", "RoundDown", "NoRound", "SmallMicroseconds"],
 )
 @pytest.mark.parametrize("tz_aware", [True, False])
 @pytest.mark.asyncio


### PR DESCRIPTION
As we roll out hexkit v6 to services, there will be a lot of similar migration logic happening. To make the rollout smoother, this PR adds a module in the mongodb migrations subpackage to perform common operations, like converting isoformat string datetimes to actual datetimes. The functions are very clearly named and have been unit tested. We can delete them if we want to in some future hexkit version.