### PR TITLE
Safe log formatting (GSI-1755)

### DIFF
--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -89,7 +89,8 @@ class JsonFormatter(Formatter):
         self._include_traceback = include_traceback
 
     def format(self, record: LogRecord) -> str:
-        """Format the specified record as a JSON string.
+        """Format the specified record as a JSON string with non-serializable types
+        converted to strings.
 
         This will format the log record as JSON with the following values (in order):
             - timestamp: The ISO 8601-formatted timestamp of the log message.
@@ -131,8 +132,8 @@ class JsonFormatter(Formatter):
                     exception["traceback"] = exc_text
             output["exception"] = exception
 
-        # Convert to JSON string
-        return json.dumps(output)
+        # Convert to JSON string with str serialization for non-serializable types
+        return json.dumps(output, default=str)
 
 
 class RecordCompiler(StreamHandler):

--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -90,7 +90,7 @@ class JsonFormatter(Formatter):
 
     def format(self, record: LogRecord) -> str:
         """Format the specified record as a JSON string with non-serializable types
-        converted to strings.
+        converted using repr.
 
         This will format the log record as JSON with the following values (in order):
             - timestamp: The ISO 8601-formatted timestamp of the log message.
@@ -132,8 +132,8 @@ class JsonFormatter(Formatter):
                     exception["traceback"] = exc_text
             output["exception"] = exception
 
-        # Convert to JSON string with str serialization for non-serializable types
-        return json.dumps(output, default=str)
+        # Use repr for non-serializable types, since this matches the default logger
+        return json.dumps(output, default=repr)
 
 
 class RecordCompiler(StreamHandler):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -20,6 +20,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Optional
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import Field, SecretBytes, SecretStr
@@ -315,6 +316,7 @@ def test_secrets_logging_config(root_logger_reset, capsys):  # noqa: F811
     class TestConfig(LoggingConfig):
         string: str = "foo"
         number: int = 42
+        uuid_: UUID = uuid4()
         secret_bytes: SecretBytes = Field(default=SecretBytes(b"silent"))
         secret_str: SecretStr = Field(default=SecretStr("silent"))
 
@@ -329,5 +331,5 @@ def test_secrets_logging_config(root_logger_reset, capsys):  # noqa: F811
     for key, value in config.model_dump().items():
         assert key in printed_log
         if not key.startswith("secret"):
-            json_value = json.dumps(value)
+            json_value = json.dumps(value, default=str)
             assert json_value in printed_log

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -340,13 +340,16 @@ def test_complex_types_in_log_detail(root_logger_reset, capsys):  # noqa: F811
     config = LoggingConfig(service_name="", service_instance_id="")
     configure_logging(config=config)
 
+    # Clear the capture buffer before logging
     out, err = capsys.readouterr()
-    printed_log = out + err
+
     test_uuid = uuid4()
     date = datetime.now()
 
     log = logging.getLogger()
     log.error("Testing", extra={"id_": test_uuid, "date": date})
+
+    # Capture the output after logging
     out, err = capsys.readouterr()
     printed_log = out + err
 


### PR DESCRIPTION
Hexkit raises an error if you pass something like a UUID to a log. The standard python logger handles this without issue, but hexkit has a custom format operation that involves [`json.dumps()`](https://github.com/ghga-de/hexkit/blob/5051c2348c4947fbf1e908c2af4128a92327a605/src/hexkit/log.py#L137). Since UUIDs and datetimes are not JSON compatible, error. This pr uses `default=repr` to handle anything that isn't json-serializable. 