### PR TITLE
Support ListParts method for object storage (GSI-2311)

### DIFF
--- a/.github/workflows/check_pyproject.yaml
+++ b/.github/workflows/check_pyproject.yaml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Common steps
         id: common
-        uses: ghga-de/gh-action-common@v6
+        uses: ghga-de/gh-action-common@v7
         with:
           python-version: '3.13'
 

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.13
         id: setup-python

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ dmypy.json
 .DS_Store
 desktop.ini
 thumbs.db
+
+# LLM Stuff
+CLAUDE.local.md
+.claude/settings.local.json
+.claude/agent-memory-local/

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.1.0"
+version = "8.2.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/.pyproject_generation/pyproject_template.toml
+++ b/.pyproject_generation/pyproject_template.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=80.10"]
+requires = ["setuptools>=82"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=80.10",
+    "setuptools>=82",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.1.0"
+version = "8.2.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -204,7 +204,19 @@ class ObjectStorageProtocol(ABC):
         max_parts: int | None = None,
         first_part_no: int | None = None,
     ) -> list[dict]:
-        """Lists the parts that have been uploaded for a specific multipart upload."""
+        """Lists the parts that have been uploaded for a specific multipart upload.
+
+        Specify `max_parts` to return a limited parts list. If not specified, all
+        parts will be returned (up to 10,000).
+
+        Specify `first_part_no` to get parts starting with that part number. If not
+        specified, retrieved parts will start with the first part. Part numbers
+        start at 1, not 0.
+
+        Raises:
+            ValueError if `max_parts` or `first_part_no` are invalid.
+            MultiPartUploadNotFoundError if no upload with `upload_id` exists.
+        """
         self._validate_bucket_id(bucket_id)
         self._validate_object_id(object_id)
         return await self._list_parts(
@@ -472,12 +484,16 @@ class ObjectStorageProtocol(ABC):
     ) -> list[dict]:
         """Lists the parts that have been uploaded for a specific multipart upload.
 
-        Specify `max_parts` to return a limited parts list. If the argument is invalid
-        or not specified, all parts will be returned (up to 10,000).
+        Specify `max_parts` to return a limited parts list. If not specified, all
+        parts will be returned (up to 10,000).
 
-        Specify `first_part_no` to get parts starting with that part number. If invalid
-        or not specified, retrieved parts will start with the first part. Part numbers
+        Specify `first_part_no` to get parts starting with that part number. If not
+        specified, retrieved parts will start with the first part. Part numbers
         start at 1, not 0.
+
+        Raises:
+            ValueError if `max_parts` or `first_part_no` are invalid.
+            MultiPartUploadNotFoundError if no upload with `upload_id` exists.
         """
         ...
 

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -470,7 +470,15 @@ class ObjectStorageProtocol(ABC):
         max_parts: int | None = None,
         first_part_no: int | None = None,
     ) -> list[dict]:
-        """Lists the parts that have been uploaded for a specific multipart upload."""
+        """Lists the parts that have been uploaded for a specific multipart upload.
+
+        Specify `max_parts` to return a limited parts list. If the argument is invalid
+        or not specified, all parts will be returned (up to 10,000).
+
+        Specify `first_part_no` to get parts starting with that part number. If invalid
+        or not specified, retrieved parts will start with the first part. Part numbers
+        start at 1, not 0.
+        """
         ...
 
     @abstractmethod

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -195,6 +195,26 @@ class ObjectStorageProtocol(ABC):
             bucket_id=bucket_id, object_id=object_id
         )
 
+    async def list_parts(
+        self,
+        *,
+        bucket_id: str,
+        object_id: str,
+        upload_id: str,
+        max_parts: int | None = None,
+        first_part_no: int | None = None,
+    ) -> list[dict]:
+        """Lists the parts that have been uploaded for a specific multipart upload."""
+        self._validate_bucket_id(bucket_id)
+        self._validate_object_id(object_id)
+        return await self._list_parts(
+            bucket_id=bucket_id,
+            object_id=object_id,
+            upload_id=upload_id,
+            max_parts=max_parts,
+            first_part_no=first_part_no,
+        )
+
     async def get_all_multipart_uploads(self, *, bucket_id: str) -> dict[str, str]:
         """Gets all active multipart uploads for the given bucket ID.
 
@@ -438,6 +458,19 @@ class ObjectStorageProtocol(ABC):
         *To be implemented by the provider. Input validation is done outside of this
         method.*
         """
+        ...
+
+    @abstractmethod
+    async def _list_parts(
+        self,
+        *,
+        bucket_id: str,
+        object_id: str,
+        upload_id: str,
+        max_parts: int | None = None,
+        first_part_no: int | None = None,
+    ) -> list[dict]:
+        """Lists the parts that have been uploaded for a specific multipart upload."""
         ...
 
     @abstractmethod

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -370,6 +370,58 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
         return uploads
 
+    async def _list_parts(
+        self,
+        *,
+        bucket_id: str,
+        object_id: str,
+        upload_id: str,
+        max_parts: int | None = None,
+        first_part_no: int | None = None,
+    ) -> list[dict]:
+        """Lists the parts that have been uploaded for a specific multipart upload."""
+        await self._assert_multipart_upload_exists(
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+        )
+
+        params: dict[str, Any] = {
+            "Bucket": bucket_id,
+            "Key": object_id,
+            "UploadId": upload_id,
+        }
+        if max_parts:
+            params["MaxParts"] = max_parts
+        if first_part_no:
+            # S3 returns parts starting *after* PartNumberMarker, so subtract 1 to get
+            #  more intuitive behavior where the first part returned is first_part_no
+            params["PartNumberMarker"] = first_part_no - 1
+
+        try:
+            if max_parts is not None:
+                # If max_parts is specified, make single call
+                response = await asyncio.to_thread(self._client.list_parts, **params)
+                return response.get("Parts", [])
+
+            # If max_parts isn't specified, paginate manually to collect all parts
+            parts: list[dict] = []
+            while True:
+                response = await asyncio.to_thread(self._client.list_parts, **params)
+                parts.extend(response.get("Parts", []))
+
+                # ListParts is limited to 1000 parts per paginated request, so repeat
+                #  the call until all parts are received (IsTruncated=False)
+                if not response.get("IsTruncated"):
+                    break
+                params["PartNumberMarker"] = response["NextPartNumberMarker"]
+            return parts
+        except botocore.exceptions.ClientError as error:
+            raise self._translate_s3_client_errors(
+                error,
+                upload_id=upload_id,
+                bucket_id=bucket_id,
+                object_id=object_id,
+            ) from error
+
     async def _get_all_multipart_uploads(self, *, bucket_id: str) -> dict[str, str]:
         """Gets all active multipart uploads for the given bucket ID.
 
@@ -506,54 +558,19 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 object_id=object_id,
             ) from error
 
-    async def _get_parts_info(
-        self,
-        *,
-        upload_id: str,
-        bucket_id: str,
-        object_id: str,
-    ) -> dict:
-        """Get information on parts uploaded as part of the specified multi-part upload."""
-        await self._assert_multipart_upload_exists(
-            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
-        )
-
-        try:
-            response_iter = await asyncio.to_thread(
-                self._client.get_paginator("list_parts").paginate,
-                Bucket=bucket_id,
-                Key=object_id,
-                UploadId=upload_id,
-            )
-            complete_response: dict[str, Any] = {}
-            for response_page in response_iter:
-                if not complete_response:
-                    complete_response = response_page
-                    continue
-                complete_response["Parts"].extend(response_page["Parts"])
-            return complete_response
-        except botocore.exceptions.ClientError as error:
-            raise self._translate_s3_client_errors(
-                error,
-                upload_id=upload_id,
-                bucket_id=bucket_id,
-                object_id=object_id,
-            ) from error
-
     async def _check_uploaded_parts(
         self,
         *,
         upload_id: str,
         bucket_id: str,
         object_id: str,
-        parts_info: dict,
+        parts_info: list[dict],
         anticipated_part_quantity: int | None = None,
         anticipated_part_size: int | None = None,
     ) -> None:
         """Check size and quantity of parts"""
         # check the part quantity:
-        parts = parts_info.get("Parts")
-        if parts is None or len(parts) == 0:
+        if not parts_info:
             raise self.MultiPartUploadConfirmError(
                 upload_id=upload_id,
                 bucket_id=bucket_id,
@@ -561,7 +578,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 reason="Zero parts received.",
             )
 
-        part_quantity = len(parts)
+        part_quantity = len(parts_info)
         if (
             anticipated_part_quantity is not None
             and part_quantity != anticipated_part_quantity
@@ -575,11 +592,11 @@ class S3ObjectStorage(ObjectStorageProtocol):
             )
 
         # check anticipated part size:
-        first_part_size = parts[0]["Size"]
-        last_part_size = parts[-1]["Size"]
+        first_part_size = parts_info[0]["Size"]
+        last_part_size = parts_info[-1]["Size"]
         if anticipated_part_size is not None:
             # if we have only one part, this is not required
-            if len(parts) > 1 and first_part_size != anticipated_part_size:
+            if len(parts_info) > 1 and first_part_size != anticipated_part_size:
                 raise self.MultiPartUploadConfirmError(
                     upload_id=upload_id,
                     bucket_id=bucket_id,
@@ -609,7 +626,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
             )
 
         # check if all parts (except the last one) conform to the size of the first one:
-        for part in parts[1 : part_quantity - 1]:
+        for part in parts_info[1 : part_quantity - 1]:
             if part["Size"] != first_part_size:
                 raise self.MultiPartUploadConfirmError(
                     upload_id=upload_id,
@@ -660,7 +677,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html?highlight=abort_multipart_upload#S3.Client.abort_multipart_upload
         # )
         try:
-            parts_info = await self._get_parts_info(
+            parts = await self._list_parts(
                 upload_id=upload_id,
                 bucket_id=bucket_id,
                 object_id=object_id,
@@ -670,8 +687,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
             return
 
         # verify that no parts are remaining:
-        parts = parts_info.get("Parts")
-        if parts is not None and len(parts) > 0:
+        if parts:
             raise self.MultiPartUploadAbortError(
                 upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
             )
@@ -691,7 +707,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         This ensures that exactly the specified number of parts exist and that all parts
         (except the last one) have the specified size.
         """
-        parts_info = await self._get_parts_info(
+        parts = await self._list_parts(
             upload_id=upload_id,
             bucket_id=bucket_id,
             object_id=object_id,
@@ -701,13 +717,12 @@ class S3ObjectStorage(ObjectStorageProtocol):
             upload_id=upload_id,
             bucket_id=bucket_id,
             object_id=object_id,
-            parts_info=parts_info,
+            parts_info=parts,
             anticipated_part_quantity=anticipated_part_quantity,
             anticipated_part_size=anticipated_part_size,
         )
 
         # construct eTags list:
-        parts = parts_info.get("Parts", [])
         part_etags = [
             {"ETag": part["ETag"], "PartNumber": part["PartNumber"]} for part in parts
         ]

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -402,12 +402,12 @@ class S3ObjectStorage(ObjectStorageProtocol):
             "UploadId": upload_id,
         }
         if max_parts is not None:
-            if isinstance(max_parts, int) and max_parts > 0:
+            if max_parts > 0:
                 params["MaxParts"] = max_parts
             else:
                 raise ValueError(f"{max_parts} is not a valid argument for max_parts")
         if first_part_no is not None:
-            if isinstance(first_part_no, int) and first_part_no > 0:
+            if first_part_no > 0:
                 # S3 returns parts starting *after* PartNumberMarker, so subtract 1 to get
                 #  more intuitive behavior where the first part returned is first_part_no
                 params["PartNumberMarker"] = first_part_no - 1

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -379,7 +379,15 @@ class S3ObjectStorage(ObjectStorageProtocol):
         max_parts: int | None = None,
         first_part_no: int | None = None,
     ) -> list[dict]:
-        """Lists the parts that have been uploaded for a specific multipart upload."""
+        """Lists the parts that have been uploaded for a specific multipart upload.
+
+        Specify `max_parts` to return a limited parts list. If the argument is invalid
+        or not specified, all parts will be returned (up to 10,000).
+
+        Specify `first_part_no` to get parts starting with that part number. If invalid
+        or not specified, retrieved parts will start with the first part. Part numbers
+        start at 1, not 0.
+        """
         await self._assert_multipart_upload_exists(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
@@ -389,9 +397,9 @@ class S3ObjectStorage(ObjectStorageProtocol):
             "Key": object_id,
             "UploadId": upload_id,
         }
-        if max_parts:
+        if isinstance(max_parts, int) and max_parts > 0:
             params["MaxParts"] = max_parts
-        if first_part_no:
+        if isinstance(first_part_no, int) and first_part_no > 0:
             # S3 returns parts starting *after* PartNumberMarker, so subtract 1 to get
             #  more intuitive behavior where the first part returned is first_part_no
             params["PartNumberMarker"] = first_part_no - 1

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -388,6 +388,10 @@ class S3ObjectStorage(ObjectStorageProtocol):
         specified, retrieved parts will start with the first part. Part numbers
         start at 1, not 0.
 
+        Returns a list of dict items, where each item contains information about one
+        file part. The dict keys are "PartNumber", "Size", "ETag", and "LastModified",
+        but additional fields may be present depending on the S3 instance setup.
+
         Raises:
             ValueError if `max_parts` or `first_part_no` are invalid.
             MultiPartUploadNotFoundError if no upload with `upload_id` exists.
@@ -582,7 +586,11 @@ class S3ObjectStorage(ObjectStorageProtocol):
         anticipated_part_quantity: int | None = None,
         anticipated_part_size: int | None = None,
     ) -> None:
-        """Check size and quantity of parts"""
+        """Check size and quantity of parts.
+
+        The items in the `parts` parameter should be dicts containing at least the
+        "Size" field where the value is the part content's size in bytes (as an int).
+        """
         # check the part quantity:
         if not parts:
             raise self.MultiPartUploadConfirmError(

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -584,13 +584,13 @@ class S3ObjectStorage(ObjectStorageProtocol):
         upload_id: str,
         bucket_id: str,
         object_id: str,
-        parts_info: list[dict],
+        parts: list[dict],
         anticipated_part_quantity: int | None = None,
         anticipated_part_size: int | None = None,
     ) -> None:
         """Check size and quantity of parts"""
         # check the part quantity:
-        if not parts_info:
+        if not parts:
             raise self.MultiPartUploadConfirmError(
                 upload_id=upload_id,
                 bucket_id=bucket_id,
@@ -598,7 +598,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 reason="Zero parts received.",
             )
 
-        part_quantity = len(parts_info)
+        part_quantity = len(parts)
         if (
             anticipated_part_quantity is not None
             and part_quantity != anticipated_part_quantity
@@ -612,11 +612,11 @@ class S3ObjectStorage(ObjectStorageProtocol):
             )
 
         # check anticipated part size:
-        first_part_size = parts_info[0]["Size"]
-        last_part_size = parts_info[-1]["Size"]
+        first_part_size = parts[0]["Size"]
+        last_part_size = parts[-1]["Size"]
         if anticipated_part_size is not None:
             # if we have only one part, this is not required
-            if len(parts_info) > 1 and first_part_size != anticipated_part_size:
+            if len(parts) > 1 and first_part_size != anticipated_part_size:
                 raise self.MultiPartUploadConfirmError(
                     upload_id=upload_id,
                     bucket_id=bucket_id,
@@ -646,7 +646,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
             )
 
         # check if all parts (except the last one) conform to the size of the first one:
-        for part in parts_info[1 : part_quantity - 1]:
+        for part in parts[1 : part_quantity - 1]:
             if part["Size"] != first_part_size:
                 raise self.MultiPartUploadConfirmError(
                     upload_id=upload_id,
@@ -737,7 +737,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
             upload_id=upload_id,
             bucket_id=bucket_id,
             object_id=object_id,
-            parts_info=parts,
+            parts=parts,
             anticipated_part_quantity=anticipated_part_quantity,
             anticipated_part_size=anticipated_part_size,
         )

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -417,22 +417,16 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 )
 
         try:
-            if max_parts is not None:
-                # If max_parts is specified, make single call
-                response = await asyncio.to_thread(self._client.list_parts, **params)
-                return response.get("Parts", [])
-
-            # If max_parts isn't specified, paginate manually to collect all parts
             parts: list[dict] = []
-            while True:
-                response = await asyncio.to_thread(self._client.list_parts, **params)
-                parts.extend(response.get("Parts", []))
+            response_iter = await asyncio.to_thread(
+                self._client.get_paginator("list_parts").paginate, **params
+            )
+            for page in response_iter:
+                parts.extend(page.get("Parts", []))
 
-                # ListParts is limited to 1000 parts per paginated request, so repeat
-                #  the call until all parts are received (IsTruncated=False)
-                if not response.get("IsTruncated"):
-                    break
-                params["PartNumberMarker"] = response["NextPartNumberMarker"]
+                # If max_parts specified, return once amount is reached
+                if max_parts and len(parts) >= max_parts:
+                    return parts[: max_parts + 1]
             return parts
         except botocore.exceptions.ClientError as error:
             raise self._translate_s3_client_errors(

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -381,12 +381,16 @@ class S3ObjectStorage(ObjectStorageProtocol):
     ) -> list[dict]:
         """Lists the parts that have been uploaded for a specific multipart upload.
 
-        Specify `max_parts` to return a limited parts list. If the argument is invalid
-        or not specified, all parts will be returned (up to 10,000).
+        Specify `max_parts` to return a limited parts list. If not specified, all
+        parts will be returned (up to 10,000).
 
-        Specify `first_part_no` to get parts starting with that part number. If invalid
-        or not specified, retrieved parts will start with the first part. Part numbers
+        Specify `first_part_no` to get parts starting with that part number. If not
+        specified, retrieved parts will start with the first part. Part numbers
         start at 1, not 0.
+
+        Raises:
+            ValueError if `max_parts` or `first_part_no` are invalid.
+            MultiPartUploadNotFoundError if no upload with `upload_id` exists.
         """
         await self._assert_multipart_upload_exists(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
@@ -397,12 +401,20 @@ class S3ObjectStorage(ObjectStorageProtocol):
             "Key": object_id,
             "UploadId": upload_id,
         }
-        if isinstance(max_parts, int) and max_parts > 0:
-            params["MaxParts"] = max_parts
-        if isinstance(first_part_no, int) and first_part_no > 0:
-            # S3 returns parts starting *after* PartNumberMarker, so subtract 1 to get
-            #  more intuitive behavior where the first part returned is first_part_no
-            params["PartNumberMarker"] = first_part_no - 1
+        if max_parts is not None:
+            if isinstance(max_parts, int) and max_parts > 0:
+                params["MaxParts"] = max_parts
+            else:
+                raise ValueError(f"{max_parts} is not a valid argument for max_parts")
+        if first_part_no is not None:
+            if isinstance(first_part_no, int) and first_part_no > 0:
+                # S3 returns parts starting *after* PartNumberMarker, so subtract 1 to get
+                #  more intuitive behavior where the first part returned is first_part_no
+                params["PartNumberMarker"] = first_part_no - 1
+            else:
+                raise ValueError(
+                    f"{first_part_no} is not a valid argument for first_part_no"
+                )
 
         try:
             if max_parts is not None:

--- a/src/hexkit/providers/testing/objstorage.py
+++ b/src/hexkit/providers/testing/objstorage.py
@@ -178,6 +178,31 @@ class InMemObjectStorage(ObjectStorageProtocol):
         await self._assert_bucket_exists(bucket_id)
         return list(self.uploads[bucket_id].get(object_id, set()))
 
+    async def _list_parts(
+        self,
+        *,
+        bucket_id: str,
+        object_id: str,
+        upload_id: str,
+        max_parts: int | None = None,
+        first_part_no: int | None = None,
+    ) -> list[dict]:
+        """Lists the parts that have been uploaded for a specific multipart upload."""
+        await self._assert_bucket_exists(bucket_id)
+        await self._assert_multipart_upload_exists(
+            upload_id=upload_id,
+            bucket_id=bucket_id,
+            object_id=object_id,
+            assert_exclusiveness=False,
+        )
+        parts = []
+        # default is to make 3 dummy parts
+        start = first_part_no or 1
+        stop = start + (max_parts or 3)
+        for i in range(start, stop):
+            parts += [{"PartNumber": i, "Size": 100, "ETag": f"etag-for-part-{i}"}]
+        return parts
+
     async def _get_all_multipart_uploads(self, *, bucket_id: str) -> dict[str, str]:
         """Gets all active multipart uploads for the given bucket ID.
 

--- a/src/hexkit/providers/testing/objstorage.py
+++ b/src/hexkit/providers/testing/objstorage.py
@@ -199,11 +199,9 @@ class InMemObjectStorage(ObjectStorageProtocol):
             object_id=object_id,
             assert_exclusiveness=False,
         )
-        if max_parts is not None and not (isinstance(max_parts, int) and max_parts > 0):
+        if max_parts is not None and max_parts <= 0:
             raise ValueError(f"{max_parts} is not a valid argument for max_parts")
-        if first_part_no is not None and not (
-            isinstance(first_part_no, int) and first_part_no > 0
-        ):
+        if first_part_no is not None and first_part_no <= 0:
             raise ValueError(
                 f"{first_part_no} is not a valid argument for first_part_no"
             )

--- a/src/hexkit/providers/testing/objstorage.py
+++ b/src/hexkit/providers/testing/objstorage.py
@@ -187,7 +187,11 @@ class InMemObjectStorage(ObjectStorageProtocol):
         max_parts: int | None = None,
         first_part_no: int | None = None,
     ) -> list[dict]:
-        """Lists the parts that have been uploaded for a specific multipart upload."""
+        """Lists the parts that have been uploaded for a specific multipart upload.
+
+        This implementation only exists to round out the protocol implementation,
+        and the return value is dummy data only.
+        """
         await self._assert_bucket_exists(bucket_id)
         await self._assert_multipart_upload_exists(
             upload_id=upload_id,
@@ -195,6 +199,15 @@ class InMemObjectStorage(ObjectStorageProtocol):
             object_id=object_id,
             assert_exclusiveness=False,
         )
+        if max_parts is not None and not (isinstance(max_parts, int) and max_parts > 0):
+            raise ValueError(f"{max_parts} is not a valid argument for max_parts")
+        if first_part_no is not None and not (
+            isinstance(first_part_no, int) and first_part_no > 0
+        ):
+            raise ValueError(
+                f"{first_part_no} is not a valid argument for first_part_no"
+            )
+
         parts = []
         # default is to make 3 dummy parts
         start = first_part_no or 1
@@ -330,15 +343,6 @@ class InMemObjectStorage(ObjectStorageProtocol):
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
 
-        params = {
-            "Bucket": bucket_id,
-            "Key": object_id,
-            "UploadId": upload_id,
-            "PartNumber": part_number,
-        }
-        # add additional parameters if any were passed
-        if part_md5:
-            params["ContentMD5"] = part_md5
         return (
             f"{self.base_url}/{bucket_id}/{object_id}/{upload_id}"
             + f"/part_no_{part_number}?{expires_after=}"

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -506,7 +506,7 @@ async def test_list_parts_high_index(s3: S3Fixture):
     for max_parts, first_part_no, expected_parts, fail_msg in [
         (None, None, [n for n in range(1, count)], "Basic pagination failed"),
         (count, None, [n for n in range(1, count)], "Failed when max_parts > 1000"),
-        (1, 1025, [1025], "Failed when targeting single part with PartNumber > 1001"),
+        (1, 1025, [1025], "Failed when targeting single part with PartNumber > 1000"),
         (None, 1025, [n for n in range(1025, count)], "Failed to get last parts"),
         (3, None, [1, 2, 3], "Failed to get first three parts with no first_part_no"),
     ]:

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -475,9 +475,50 @@ async def test_list_parts_invalid_args(s3: S3Fixture):
         bucket_id=bucket_id,
         object_id=object_id,
         upload_id=upload_id,
+        max_parts=1001,
         first_part_no=10,
     )
     assert results == []
+
+
+async def test_list_parts_high_index(s3: S3Fixture):
+    """Verify that `.list_parts()` works as expected when part counts are over 1000,
+    which is the default max part count per pagination window.
+    """
+    # Create an MPU with 1 part uploaded
+    upload_id, bucket_id, object_id = await s3.prepare_non_completed_upload()
+    count = 1030
+
+    # Upload enough parts at minimum part size to exceed max pagination window size (1000)
+    for i in range(2, count + 1):  # Add 1 so `count` is accurate, not off by 1
+        await upload_part_of_size(
+            storage_dao=s3.storage,
+            upload_id=upload_id,
+            bucket_id=bucket_id,
+            object_id=object_id,
+            size=5 * 1024**2,
+            part_number=i,
+        )
+
+    # Perform tests inside a single setup instead of uploading all parts anew each time:
+    parts = []
+    for max_parts, first_part_no, expected_parts, fail_msg in [
+        (None, None, [n for n in range(1, count + 1)], "Basic pagination failed"),
+        (count, None, [n for n in range(1, count + 1)], "Failed when max_parts > 1000"),
+        (1, 1025, [1025], "Failed when targeting single part with PartNumber > 1001"),
+        (None, 1025, [n for n in range(1025, count + 1)], "Failed to get last parts"),
+        (3, None, [1, 2, 3], "Failed to get first three parts with no first_part_no"),
+    ]:
+        parts = await s3.storage.list_parts(
+            bucket_id=bucket_id,
+            object_id=object_id,
+            upload_id=upload_id,
+            max_parts=max_parts,
+            first_part_no=first_part_no,
+        )
+
+        # Inspect PartNumber to verify results
+        assert [p["PartNumber"] for p in parts] == expected_parts, fail_msg
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -418,16 +418,16 @@ async def test_list_parts(s3: S3Fixture):
     assert results_with_offset[0]["PartNumber"] == 2
     assert results_with_offset[1]["PartNumber"] == 3
 
-    # Use the two optional params together to get part 2 only
+    # Use the two optional params together to get part 1 only
     part_2 = await s3.storage.list_parts(
         bucket_id=bucket_id,
         object_id=object_id,
         upload_id=upload_id,
         max_parts=1,
-        first_part_no=2,
+        first_part_no=1,
     )
     assert len(part_2) == 1
-    assert part_2[0]["PartNumber"] == 2
+    assert part_2[0]["PartNumber"] == 1
 
     # Create a new MPU with no parts uploaded
     uid = await s3.storage.init_multipart_upload(

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -429,11 +429,6 @@ async def test_list_parts(s3: S3Fixture):
     )
     assert not no_parts
 
-    # Abort the upload
-    await s3.storage.abort_multipart_upload(
-        bucket_id=bucket_id, object_id="throwaway", upload_id=uid
-    )
-
 
 async def test_list_parts_invalid_args(s3: S3Fixture):
     """Test to make sure list_parts() validates args correctly."""

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -481,6 +481,7 @@ async def test_list_parts_invalid_args(s3: S3Fixture):
     assert results == []
 
 
+@pytest.mark.skip(reason="This test uses a large amount of memory, run only locally.")
 async def test_list_parts_high_index(s3: S3Fixture):
     """Verify that `.list_parts()` works as expected when part counts are over 1000,
     which is the default max part count per pagination window.

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -470,6 +470,15 @@ async def test_list_parts_invalid_args(s3: S3Fixture):
             first_part_no=0,
         )
 
+    # Illustrate that setting first_part_no higher than actual part count returns []
+    results = await s3.storage.list_parts(
+        bucket_id=bucket_id,
+        object_id=object_id,
+        upload_id=upload_id,
+        first_part_no=10,
+    )
+    assert results == []
+
 
 @pytest.mark.parametrize(
     "part_sizes, anticipated_part_size, anticipated_part_quantity, exception",

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -418,6 +418,23 @@ async def test_list_parts(s3: S3Fixture):
     assert results_with_offset[0]["PartNumber"] == 2
     assert results_with_offset[1]["PartNumber"] == 3
 
+    # Try with invalid max_parts
+    invalid_max_parts = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, max_parts=-9
+    )
+    assert len(invalid_max_parts) == 3
+
+    invalid_first_part_no = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, first_part_no=-9
+    )
+    assert len(invalid_first_part_no) == 3
+
+    # Try with valid but nonexistent first_part_no
+    out_of_range_first_part_no = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, first_part_no=9
+    )
+    assert len(out_of_range_first_part_no) == 0
+
     # Create a new MPU with no parts uploaded
     uid = await s3.storage.init_multipart_upload(
         bucket_id=bucket_id, object_id="throwaway"

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -377,6 +377,64 @@ async def test_md5_in_part_url(s3: S3Fixture):
     assert "content-md5=dummy-md5" in url
 
 
+async def test_list_parts(s3: S3Fixture):
+    """Test that list_parts() works in the happy case."""
+    # Create an MPU with 1 part uploaded
+    upload_id, bucket_id, object_id = await s3.prepare_non_completed_upload()
+    parts_list = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id
+    )
+    assert len(parts_list) == 1
+
+    # Upload two more parts
+    for i in range(2, 4):
+        await upload_part_of_size(
+            storage_dao=s3.storage,
+            upload_id=upload_id,
+            bucket_id=bucket_id,
+            object_id=object_id,
+            size=6 * 1024**2,
+            part_number=i,
+        )
+
+    # Check list of parts
+    parts_list = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id
+    )
+    assert len(parts_list) == 3
+
+    # Verify that the limiter "max_parts" works
+    results_with_limit = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, max_parts=1
+    )
+    assert len(results_with_limit) == 1
+    assert results_with_limit[0]["PartNumber"] == 1
+
+    # Verify that the offset "first_part_no" works
+    results_with_offset = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, first_part_no=2
+    )
+    assert len(results_with_offset) == 2
+    assert results_with_offset[0]["PartNumber"] == 2
+    assert results_with_offset[1]["PartNumber"] == 3
+
+    # Create a new MPU with no parts uploaded
+    uid = await s3.storage.init_multipart_upload(
+        bucket_id=bucket_id, object_id="throwaway"
+    )
+
+    # Check parts list again, should get empty list
+    no_parts = await s3.storage.list_parts(
+        bucket_id=bucket_id, object_id="throwaway", upload_id=uid
+    )
+    assert not no_parts
+
+    # Abort the upload
+    await s3.storage.abort_multipart_upload(
+        bucket_id=bucket_id, object_id="throwaway", upload_id=uid
+    )
+
+
 @pytest.mark.parametrize(
     "part_sizes, anticipated_part_size, anticipated_part_quantity, exception",
     [

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -418,6 +418,17 @@ async def test_list_parts(s3: S3Fixture):
     assert results_with_offset[0]["PartNumber"] == 2
     assert results_with_offset[1]["PartNumber"] == 3
 
+    # Use the two optional params together to get part 2 only
+    part_2 = await s3.storage.list_parts(
+        bucket_id=bucket_id,
+        object_id=object_id,
+        upload_id=upload_id,
+        max_parts=1,
+        first_part_no=2,
+    )
+    assert len(part_2) == 1
+    assert part_2[0]["PartNumber"] == 2
+
     # Create a new MPU with no parts uploaded
     uid = await s3.storage.init_multipart_upload(
         bucket_id=bucket_id, object_id="throwaway"

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -487,10 +487,10 @@ async def test_list_parts_high_index(s3: S3Fixture):
     """
     # Create an MPU with 1 part uploaded
     upload_id, bucket_id, object_id = await s3.prepare_non_completed_upload()
-    count = 1030
+    count = 1031
 
     # Upload enough parts at minimum part size to exceed max pagination window size (1000)
-    for i in range(2, count + 1):  # Add 1 so `count` is accurate, not off by 1
+    for i in range(2, count):
         await upload_part_of_size(
             storage_dao=s3.storage,
             upload_id=upload_id,
@@ -503,10 +503,10 @@ async def test_list_parts_high_index(s3: S3Fixture):
     # Perform tests inside a single setup instead of uploading all parts anew each time:
     parts = []
     for max_parts, first_part_no, expected_parts, fail_msg in [
-        (None, None, [n for n in range(1, count + 1)], "Basic pagination failed"),
-        (count, None, [n for n in range(1, count + 1)], "Failed when max_parts > 1000"),
+        (None, None, [n for n in range(1, count)], "Basic pagination failed"),
+        (count, None, [n for n in range(1, count)], "Failed when max_parts > 1000"),
         (1, 1025, [1025], "Failed when targeting single part with PartNumber > 1001"),
-        (None, 1025, [n for n in range(1025, count + 1)], "Failed to get last parts"),
+        (None, 1025, [n for n in range(1025, count)], "Failed to get last parts"),
         (3, None, [1, 2, 3], "Failed to get first three parts with no first_part_no"),
     ]:
         parts = await s3.storage.list_parts(

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -418,23 +418,6 @@ async def test_list_parts(s3: S3Fixture):
     assert results_with_offset[0]["PartNumber"] == 2
     assert results_with_offset[1]["PartNumber"] == 3
 
-    # Try with invalid max_parts
-    invalid_max_parts = await s3.storage.list_parts(
-        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, max_parts=-9
-    )
-    assert len(invalid_max_parts) == 3
-
-    invalid_first_part_no = await s3.storage.list_parts(
-        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, first_part_no=-9
-    )
-    assert len(invalid_first_part_no) == 3
-
-    # Try with valid but nonexistent first_part_no
-    out_of_range_first_part_no = await s3.storage.list_parts(
-        bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, first_part_no=9
-    )
-    assert len(out_of_range_first_part_no) == 0
-
     # Create a new MPU with no parts uploaded
     uid = await s3.storage.init_multipart_upload(
         bucket_id=bucket_id, object_id="throwaway"
@@ -450,6 +433,36 @@ async def test_list_parts(s3: S3Fixture):
     await s3.storage.abort_multipart_upload(
         bucket_id=bucket_id, object_id="throwaway", upload_id=uid
     )
+
+
+async def test_list_parts_invalid_args(s3: S3Fixture):
+    """Test to make sure list_parts() validates args correctly."""
+    # Create an MPU with 1 part uploaded
+    upload_id, bucket_id, object_id = await s3.prepare_non_completed_upload()
+
+    # Try with invalid max_parts
+    with pytest.raises(ValueError):
+        _ = await s3.storage.list_parts(
+            bucket_id=bucket_id, object_id=object_id, upload_id=upload_id, max_parts=-9
+        )
+
+    # Try with negative first_part_no
+    with pytest.raises(ValueError):
+        _ = await s3.storage.list_parts(
+            bucket_id=bucket_id,
+            object_id=object_id,
+            upload_id=upload_id,
+            first_part_no=-9,
+        )
+
+    # Try with first_part_no set to 0
+    with pytest.raises(ValueError):
+        _ = await s3.storage.list_parts(
+            bucket_id=bucket_id,
+            object_id=object_id,
+            upload_id=upload_id,
+            first_part_no=0,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_in_mem_objstorage.py
+++ b/tests/unit/test_in_mem_objstorage.py
@@ -564,3 +564,95 @@ async def test_get_all_multipart_uploads():
         upload_id=upload_id2, bucket_id=BUCKET1, object_id=object_id2
     )
     assert not await storage.get_all_multipart_uploads(bucket_id=BUCKET1)
+
+
+async def test_list_parts_normal():
+    """Test the dummy implementation of `.list_parts()`"""
+    storage = InMemObjectStorage()
+    await storage.create_bucket(BUCKET1)
+    upload_id = await storage.init_multipart_upload(
+        bucket_id=BUCKET1, object_id=OBJECT1
+    )
+
+    # Default call: returns 3 dummy parts starting at part number 1
+    parts = await storage.list_parts(
+        bucket_id=BUCKET1, object_id=OBJECT1, upload_id=upload_id
+    )
+    assert len(parts) == 3
+    assert [p["PartNumber"] for p in parts] == [1, 2, 3]
+
+    # max_parts limits the number of results returned
+    parts = await storage.list_parts(
+        bucket_id=BUCKET1, object_id=OBJECT1, upload_id=upload_id, max_parts=1
+    )
+    assert len(parts) == 1
+    assert parts[0]["PartNumber"] == 1
+
+    # first_part_no shifts the starting part number
+    parts = await storage.list_parts(
+        bucket_id=BUCKET1, object_id=OBJECT1, upload_id=upload_id, first_part_no=2
+    )
+    assert len(parts) == 3
+    assert [p["PartNumber"] for p in parts] == [2, 3, 4]
+
+    # Combine max_parts and first_part_no together
+    parts = await storage.list_parts(
+        bucket_id=BUCKET1,
+        object_id=OBJECT1,
+        upload_id=upload_id,
+        max_parts=2,
+        first_part_no=3,
+    )
+    assert len(parts) == 2
+    assert [p["PartNumber"] for p in parts] == [3, 4]
+
+    # Each part dict has the expected keys
+    for part in parts:
+        assert "PartNumber" in part
+        assert "Size" in part
+        assert "ETag" in part
+
+
+async def test_list_parts_error():
+    """Test the `.list_parts()` method with bad args for max_parts and first_part_no."""
+    storage = InMemObjectStorage()
+
+    # Should raise error when bucket doesn't exist
+    with pytest.raises(InMemObjectStorage.BucketNotFoundError):
+        await storage.list_parts(bucket_id=BUCKET1, object_id="junk", upload_id="junk")
+
+    # Create buckets
+    await storage.create_bucket(BUCKET1)
+
+    # Should raise an error with the upload doesn't exist
+    with pytest.raises(InMemObjectStorage.MultiPartUploadNotFoundError):
+        await storage.list_parts(bucket_id=BUCKET1, object_id="junk", upload_id="junk")
+
+    # Create a multipart upload
+    upload_id = await storage.init_multipart_upload(
+        bucket_id=BUCKET1, object_id=OBJECT1
+    )
+
+    # Try with invalid max_parts
+    with pytest.raises(ValueError):
+        _ = await storage.list_parts(
+            bucket_id=BUCKET1, object_id=OBJECT1, upload_id=upload_id, max_parts=-9
+        )
+
+    # Try with negative first_part_no
+    with pytest.raises(ValueError):
+        _ = await storage.list_parts(
+            bucket_id=BUCKET1,
+            object_id=OBJECT1,
+            upload_id=upload_id,
+            first_part_no=-9,
+        )
+
+    # Try with first_part_no set to 0
+    with pytest.raises(ValueError):
+        _ = await storage.list_parts(
+            bucket_id=BUCKET1,
+            object_id=OBJECT1,
+            upload_id=upload_id,
+            first_part_no=0,
+        )


### PR DESCRIPTION
Adds a new `list_parts()` method to the `ObjectStorageProtocol` and the `S3ObjectStorage` classes.

In addition to bucket/object/upload IDs, the method optionally accepts `max_parts` and `first_part_no`. 

If `max_parts` is specified, the results are capped at that amount.

If `first_part_no` is specified, the list of returned parts will start with that part number, if possible.

`ValueError` is raised if either `max_parts` or `first_part_no` are specified with invalid arguments.

Bumps hexkit to version `8.2.0`