### PR TITLE
Add env_nested_delimiter to SettingsConfigDict

### DIFF
--- a/src/hexkit/config.py
+++ b/src/hexkit/config.py
@@ -150,6 +150,7 @@ def config_from_yaml(
                     frozen=True,
                     env_prefix=f"{prefix}_",
                     env_file=(".env", dotenv_prefix / ".env"),
+                    env_nested_delimiter="__",
                 )
 
                 @classmethod


### PR DESCRIPTION
It seems like the default is `None` for `env_nested_delimiter` in [pydantic](https://pydantic.dev/docs/validation/latest/api/pydantic_settings/#pydantic_settings.BaseSettings.__init__(_env_nested_delimiter)). However, in `UCS` I need to be able to overwrite the field `auth_key` in the objects `uos_auth_config` and `wps_auth_config`. That should do the trick.