### PR TITLE
DAO Pagination (GSI-2412)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.2.1"
+version = "8.3.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.2.1"
+version = "8.3.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -223,7 +223,13 @@ class Dao(typing.Protocol[Dto]):
         """
         ...
 
-    def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
+    def find_all(
+        self,
+        *,
+        mapping: Mapping[str, Any],
+        skip: int | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -235,10 +241,19 @@ class Dao(typing.Protocol[Dto]):
             mapping:
                 A mapping where the keys correspond to the names of resource fields
                 and the values correspond to the actual values of the resource fields.
+            skip:
+                Number of matching resources to skip before yielding results.
+                Defaults to None (no skipping).
+            limit:
+                Maximum number of resources to yield. Defaults to None (no limit).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO
             model.
+
+        Raises:
+            InvalidMappingError: If `mapping` doesn't pass validation.
+            ValueError: if `skip` or `limit` are less than 0.
         """
         ...
 

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -20,7 +20,7 @@ with the database.
 
 import typing
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Collection, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Mapping
 from contextlib import AbstractAsyncContextManager
 from functools import partial
 from typing import Any, Generic, Literal, TypeVar
@@ -35,6 +35,7 @@ __all__ = [
     "Dao",
     "DaoFactoryProtocol",
     "FindError",
+    "FindResult",
     "MultipleHitsFoundError",
     "ResourceAlreadyExistsError",
     "ResourceNotFoundError",
@@ -140,6 +141,39 @@ class DbTimeoutError(DaoError):
 UUID4Field = partial(Field, default_factory=uuid4)
 
 
+class FindResult(AsyncIterator[Dto]):
+    """An async-iterable result from find_all() that also exposes pagination metadata.
+
+    The `total_count()` method performs an additional count query on first call (lazily)
+    and caches the result for subsequent calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        results_iterator: AsyncIterator[Dto],
+        get_total_count: Callable[[], Awaitable[int]],
+    ) -> None:
+        self._iterator = results_iterator
+        self._get_total_count = get_total_count
+        self._cached_total: int | None = None
+
+    def __aiter__(self) -> "FindResult[Dto]":  # noqa: D105
+        return self
+
+    async def __anext__(self) -> Dto:  # noqa: D105
+        return await self._iterator.__anext__()
+
+    async def total_count(self) -> int:
+        """Total number of matching documents, ignoring skip and limit.
+
+        The result is cached after the first call.
+        """
+        if self._cached_total is None:
+            self._cached_total = await self._get_total_count()
+        return self._cached_total
+
+
 class Dao(typing.Protocol[Dto]):
     """A duck type with methods common to all DAOs."""
 
@@ -233,7 +267,7 @@ class Dao(typing.Protocol[Dto]):
         skip: int | None = None,
         limit: int | None = None,
         sort: SortSpec | None = None,
-    ) -> AsyncIterator[Dto]:
+    ) -> "FindResult[Dto]":
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -257,8 +291,7 @@ class Dao(typing.Protocol[Dto]):
                 ensure consistent, deterministic results. Defaults to None (no sort).
 
         Returns:
-            An AsyncIterator of hits. All hits are in the form of the respective DTO
-            model.
+            A FindResult that is async-iterable and also provides total_count().
 
         Raises:
             InvalidMappingError: If `mapping` doesn't pass validation.

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -281,6 +281,7 @@ class Dao(typing.Protocol[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+                Specifying 0 is interpreted literally and returns no results.
             sort:
                 A list of field names defining the sort order, where field names
                 prefixed with "-" indicate *descending* order. For example, if sort is

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Collection, Mapping
 from contextlib import AbstractAsyncContextManager
 from functools import partial
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -38,9 +38,12 @@ __all__ = [
     "MultipleHitsFoundError",
     "ResourceAlreadyExistsError",
     "ResourceNotFoundError",
+    "SortSpec",
     "UUID4Field",
     "UniqueConstraintViolationError",
 ]
+
+SortSpec = list[tuple[str, Literal[1, -1]]]
 
 
 class IndexBase(ABC):
@@ -229,6 +232,7 @@ class Dao(typing.Protocol[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
+        sort: SortSpec | None = None,
     ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
@@ -246,6 +250,11 @@ class Dao(typing.Protocol[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+            sort:
+                A list of (field_name, sort_order) pairs defining the sort order,
+                where sort_order is 1 (ascending) or -1 (descending). When paginating
+                with skip/limit, providing a sort order is strongly recommended to
+                ensure consistent, deterministic results. Defaults to None (no sort).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Awaitable, Callable, Collection, Mapping
 from contextlib import AbstractAsyncContextManager
 from functools import partial
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, TypeVar
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -39,12 +39,9 @@ __all__ = [
     "MultipleHitsFoundError",
     "ResourceAlreadyExistsError",
     "ResourceNotFoundError",
-    "SortSpec",
     "UUID4Field",
     "UniqueConstraintViolationError",
 ]
-
-SortSpec = list[tuple[str, Literal[1, -1]]]
 
 
 class IndexBase(ABC):
@@ -266,7 +263,7 @@ class Dao(typing.Protocol[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
-        sort: SortSpec | None = None,
+        sort: list[str] | None = None,
     ) -> "FindResult[Dto]":
         """Find all resources that match the specified mapping.
 
@@ -285,10 +282,13 @@ class Dao(typing.Protocol[Dto]):
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
             sort:
-                A list of (field_name, sort_order) pairs defining the sort order,
-                where sort_order is 1 (ascending) or -1 (descending). When paginating
-                with skip/limit, providing a sort order is strongly recommended to
-                ensure consistent, deterministic results. Defaults to None (no sort).
+                A list of field names defining the sort order, where field names
+                prefixed with "-" indicate *descending* order. For example, if sort is
+                specified as `["name", "-age"]`, the results would be sorted first by
+                "name" in ascending order, then by "age" in descending order. When
+                paginating with skip/limit, providing a sort order is strongly
+                recommended to ensure consistent, deterministic results. Defaults to
+                None (no sort).
 
         Returns:
             A FindResult that is async-iterable and also provides total_count().

--- a/src/hexkit/providers/mongodb/provider/dao.py
+++ b/src/hexkit/providers/mongodb/provider/dao.py
@@ -311,7 +311,7 @@ class MongoDbDao(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    def find_all(
+    def find_all(  # noqa: C901
         self,
         *,
         mapping: Mapping[str, Any],
@@ -335,6 +335,7 @@ class MongoDbDao(Generic[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+                Specifying 0 is interpreted literally and returns no results.
             sort:
                 A list of field names defining the sort order, where field names
                 prefixed with "-" indicate *descending* order. For example, if sort is
@@ -348,10 +349,10 @@ class MongoDbDao(Generic[Dto]):
             A FindResult that is async-iterable and also provides total_count().
         """
         skip = skip or 0
-        limit = limit or 0
+
         if skip < 0:
             raise ValueError("skip must be >= 0")
-        if limit < 0:
+        if limit is not None and limit < 0:
             raise ValueError("limit must be >= 0")
 
         validate_find_mapping(mapping, dto_model=self._dto_model)
@@ -368,17 +369,30 @@ class MongoDbDao(Generic[Dto]):
 
         collection = self._collection
 
+        async def _total_count() -> int:
+            with translate_pymongo_errors():
+                return await collection.count_documents(filter=mapping)
+
+        if limit == 0:
+
+            async def _empty_iter() -> AsyncIterator[Dto]:
+                return
+                yield  # turns this into an async generator
+
+            return FindResult(
+                results_iterator=_empty_iter(), get_total_count=_total_count
+            )
+
         async def _iter() -> AsyncIterator[Dto]:
             with translate_pymongo_errors():
                 cursor = collection.find(filter=mapping)
                 if sort:
                     cursor = cursor.sort(mongodb_sort)
-                async for document in cursor.skip(skip).limit(limit):
+                cursor = cursor.skip(skip)
+                if limit:
+                    cursor = cursor.limit(limit)
+                async for document in cursor:
                     yield self._document_to_dto(document)
-
-        async def _total_count() -> int:
-            with translate_pymongo_errors():
-                return await collection.count_documents(filter=mapping)
 
         return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 

--- a/src/hexkit/providers/mongodb/provider/dao.py
+++ b/src/hexkit/providers/mongodb/provider/dao.py
@@ -33,6 +33,7 @@ from hexkit.protocols.dao import (
     Dao,
     DaoFactoryProtocol,
     Dto,
+    FindResult,
     IndexBase,
     InvalidFindMappingError,
     MultipleHitsFoundError,
@@ -311,14 +312,14 @@ class MongoDbDao(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    async def find_all(
+    def find_all(
         self,
         *,
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
         sort: SortSpec | None = None,
-    ) -> AsyncIterator[Dto]:
+    ) -> FindResult[Dto]:
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -341,8 +342,7 @@ class MongoDbDao(Generic[Dto]):
                 Defaults to None (no sort).
 
         Returns:
-            An AsyncIterator of hits. All hits are in the form of the respective DTO
-            model.
+            A FindResult that is async-iterable and also provides total_count().
         """
         skip = skip or 0
         limit = limit or 0
@@ -357,14 +357,21 @@ class MongoDbDao(Generic[Dto]):
         if sort:
             sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
 
-        with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping)
-            if sort:
-                cursor = cursor.sort(sort)
-            cursor = cursor.skip(skip).limit(limit)
+        collection = self._collection
 
-            async for document in cursor:
-                yield self._document_to_dto(document)
+        async def _iter() -> AsyncIterator[Dto]:
+            with translate_pymongo_errors():
+                cursor = collection.find(filter=mapping)
+                if sort:
+                    cursor = cursor.sort(sort)
+                async for document in cursor.skip(skip).limit(limit):
+                    yield self._document_to_dto(document)
+
+        async def _total_count() -> int:
+            with translate_pymongo_errors():
+                return await collection.count_documents(filter=mapping)
+
+        return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 
     @classmethod
     def with_transaction(cls) -> AbstractAsyncContextManager["Dao[Dto]"]:

--- a/src/hexkit/providers/mongodb/provider/dao.py
+++ b/src/hexkit/providers/mongodb/provider/dao.py
@@ -40,7 +40,6 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
-    SortSpec,
     UniqueConstraintViolationError,
 )
 from hexkit.providers.mongodb.config import MongoDbConfig
@@ -318,7 +317,7 @@ class MongoDbDao(Generic[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
-        sort: SortSpec | None = None,
+        sort: list[str] | None = None,
     ) -> FindResult[Dto]:
         """Find all resources that match the specified mapping.
 
@@ -337,9 +336,13 @@ class MongoDbDao(Generic[Dto]):
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
             sort:
-                A list of (field_name, sort_order) pairs. sort_order is 1 (ascending)
-                or -1 (descending). Strongly recommended when using skip/limit.
-                Defaults to None (no sort).
+                A list of field names defining the sort order, where field names
+                prefixed with "-" indicate *descending* order. For example, if sort is
+                specified as `["name", "-age"]`, the results would be sorted first by
+                "name" in ascending order, then by "age" in descending order. When
+                paginating with skip/limit, providing a sort order is strongly
+                recommended to ensure consistent, deterministic results. Defaults to
+                None (no sort).
 
         Returns:
             A FindResult that is async-iterable and also provides total_count().
@@ -354,8 +357,14 @@ class MongoDbDao(Generic[Dto]):
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
-        if sort:
-            sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
+        # Convert generic sort spec to MongoDB-specific sort spec
+        mongodb_sort: list[tuple[str, int]] = []
+        for spec in sort or []:
+            field = spec.removeprefix("-")
+            order = 1 if field == spec else -1
+            if field == self._id_field:
+                field = "_id"
+            mongodb_sort.append((field, order))
 
         collection = self._collection
 
@@ -363,7 +372,7 @@ class MongoDbDao(Generic[Dto]):
             with translate_pymongo_errors():
                 cursor = collection.find(filter=mapping)
                 if sort:
-                    cursor = cursor.sort(sort)
+                    cursor = cursor.sort(mongodb_sort)
                 async for document in cursor.skip(skip).limit(limit):
                     yield self._document_to_dto(document)
 

--- a/src/hexkit/providers/mongodb/provider/dao.py
+++ b/src/hexkit/providers/mongodb/provider/dao.py
@@ -65,7 +65,7 @@ def validate_find_mapping(mapping: Mapping[str, Any], *, dto_model: type[Dto]):
     by checking if the mapping keys exist as model fields.
 
     Raises:
-        InvalidMappingError: If validation fails.
+        InvalidMappingError: If `mapping` doesn't pass validation.
     """
     try:
         validate_fields_in_model(model=dto_model, fields=set(mapping))
@@ -310,7 +310,13 @@ class MongoDbDao(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    async def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
+    async def find_all(
+        self,
+        *,
+        mapping: Mapping[str, Any],
+        skip: int | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -322,16 +328,28 @@ class MongoDbDao(Generic[Dto]):
             mapping:
                 A mapping where the keys correspond to the names of resource fields
                 and the values correspond to the actual values of the resource fields.
+            skip:
+                Number of matching resources to skip before yielding results.
+                Defaults to None (no skipping).
+            limit:
+                Maximum number of resources to yield. Defaults to None (no limit).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO
             model.
         """
+        skip = skip or 0
+        limit = limit or 0
+        if skip < 0:
+            raise ValueError("skip must be >= 0")
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
         with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping)
+            cursor = self._collection.find(filter=mapping).skip(skip).limit(limit)
 
             async for document in cursor:
                 yield self._document_to_dto(document)

--- a/src/hexkit/providers/mongodb/provider/dao.py
+++ b/src/hexkit/providers/mongodb/provider/dao.py
@@ -39,6 +39,7 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
+    SortSpec,
     UniqueConstraintViolationError,
 )
 from hexkit.providers.mongodb.config import MongoDbConfig
@@ -316,6 +317,7 @@ class MongoDbDao(Generic[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
+        sort: SortSpec | None = None,
     ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
@@ -333,6 +335,10 @@ class MongoDbDao(Generic[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+            sort:
+                A list of (field_name, sort_order) pairs. sort_order is 1 (ascending)
+                or -1 (descending). Strongly recommended when using skip/limit.
+                Defaults to None (no sort).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO
@@ -348,8 +354,14 @@ class MongoDbDao(Generic[Dto]):
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
+        if sort:
+            sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
+
         with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping).skip(skip).limit(limit)
+            cursor = self._collection.find(filter=mapping)
+            if sort:
+                cursor = cursor.sort(sort)
+            cursor = cursor.skip(skip).limit(limit)
 
             async for document in cursor:
                 yield self._document_to_dto(document)

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -42,6 +42,7 @@ from hexkit.custom_types import ID, JsonObject
 from hexkit.protocols.dao import (
     Dao,
     Dto,
+    FindResult,
     ResourceNotFoundError,
     SortSpec,
     UniqueConstraintViolationError,
@@ -370,14 +371,14 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    async def find_all(
+    def find_all(
         self,
         *,
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
         sort: SortSpec | None = None,
-    ) -> AsyncIterator[Dto]:
+    ) -> FindResult[Dto]:
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -400,8 +401,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                 Defaults to None (no sort).
 
         Returns:
-            An AsyncIterator of hits. All hits are in the form of the respective DTO
-            model.
+            A FindResult that is async-iterable and also provides total_count().
 
         Raises:
             InvalidMappingError: If `mapping` doesn't pass validation.
@@ -420,18 +420,28 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         if sort:
             sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
 
-        with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping)
-            if sort:
-                cursor = cursor.sort(sort)
-            cursor = cursor.skip(skip).limit(limit)
+        id_field = self._id_field
+        dto_model = self._dto_model
+        collection = self._collection
 
-            async for document in cursor:
-                if document.get("__metadata__", {}).get("deleted", False):
-                    continue
-                yield document_to_dto(
-                    document, id_field=self._id_field, dto_model=self._dto_model
-                )
+        async def _iter() -> AsyncIterator[Dto]:
+            with translate_pymongo_errors():
+                cursor = collection.find(filter=mapping)
+                if sort:
+                    cursor = cursor.sort(sort)
+                async for document in cursor.skip(skip).limit(limit):
+                    if document.get("__metadata__", {}).get("deleted", False):
+                        continue
+                    yield document_to_dto(
+                        document, id_field=id_field, dto_model=dto_model
+                    )
+
+        async def _total_count() -> int:
+            not_deleted = {**mapping, "__metadata__.deleted": {"$ne": True}}
+            with translate_pymongo_errors():
+                return await collection.count_documents(filter=not_deleted)
+
+        return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 
     async def insert(self, dto: Dto) -> None:
         """Create a new resource.

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -370,7 +370,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    def find_all(
+    def find_all(  # noqa: C901
         self,
         *,
         mapping: Mapping[str, Any],
@@ -394,6 +394,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+                Specifying 0 is interpreted literally and returns no results.
             sort:
                 A list of field names defining the sort order, where field names
                 prefixed with "-" indicate *descending* order. For example, if sort is
@@ -411,10 +412,9 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
             ValueError: if `skip` or `limit` are less than 0.
         """
         skip = skip or 0
-        limit = limit or 0
         if skip < 0:
             raise ValueError("skip must be >= 0")
-        if limit < 0:
+        if limit is not None and limit < 0:
             raise ValueError("limit must be >= 0")
 
         validate_find_mapping(mapping, dto_model=self._dto_model)
@@ -432,21 +432,34 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                 field = "_id"
             mongodb_sort.append((field, order))
 
-        async def _iter() -> AsyncIterator[Dto]:
-            with translate_pymongo_errors():
-                cursor = self._collection.find(filter=mapping_without_deleted)
-                if sort:
-                    cursor = cursor.sort(mongodb_sort)
-                async for document in cursor.skip(skip).limit(limit):
-                    yield document_to_dto(
-                        document, id_field=self._id_field, dto_model=self._dto_model
-                    )
+        collection = self._collection
 
         async def _total_count() -> int:
             with translate_pymongo_errors():
-                return await self._collection.count_documents(
-                    filter=mapping_without_deleted
-                )
+                return await collection.count_documents(filter=mapping_without_deleted)
+
+        if limit == 0:
+
+            async def _empty_iter() -> AsyncIterator[Dto]:
+                return
+                yield  # turns this into an async generator
+
+            return FindResult(
+                results_iterator=_empty_iter(), get_total_count=_total_count
+            )
+
+        async def _iter() -> AsyncIterator[Dto]:
+            with translate_pymongo_errors():
+                cursor = collection.find(filter=mapping_without_deleted)
+                if sort:
+                    cursor = cursor.sort(mongodb_sort)
+                cursor = cursor.skip(skip)
+                if limit:
+                    cursor = cursor.limit(limit)
+                async for document in cursor:
+                    yield document_to_dto(
+                        document, id_field=self._id_field, dto_model=self._dto_model
+                    )
 
         return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -44,7 +44,6 @@ from hexkit.protocols.dao import (
     Dto,
     FindResult,
     ResourceNotFoundError,
-    SortSpec,
     UniqueConstraintViolationError,
 )
 from hexkit.protocols.daopub import DaoPublisher, DaoPublisherFactoryProtocol
@@ -377,7 +376,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
-        sort: SortSpec | None = None,
+        sort: list[str] | None = None,
     ) -> FindResult[Dto]:
         """Find all resources that match the specified mapping.
 
@@ -396,9 +395,13 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
             sort:
-                A list of (field_name, sort_order) pairs. sort_order is 1 (ascending)
-                or -1 (descending). Strongly recommended when using skip/limit.
-                Defaults to None (no sort).
+                A list of field names defining the sort order, where field names
+                prefixed with "-" indicate *descending* order. For example, if sort is
+                specified as `["name", "-age"]`, the results would be sorted first by
+                "name" in ascending order, then by "age" in descending order. When
+                paginating with skip/limit, providing a sort order is strongly
+                recommended to ensure consistent, deterministic results. Defaults to
+                None (no sort).
 
         Returns:
             A FindResult that is async-iterable and also provides total_count().
@@ -420,26 +423,30 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         # Ensure we don't retrieve deleted docs
         mapping_without_deleted = {**mapping, "__metadata__.deleted": False}
 
-        if sort:
-            sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
-
-        id_field = self._id_field
-        dto_model = self._dto_model
-        collection = self._collection
+        # Convert generic sort spec to MongoDB-specific sort spec
+        mongodb_sort: list[tuple[str, int]] = []
+        for spec in sort or []:
+            field = spec.removeprefix("-")
+            order = 1 if field == spec else -1
+            if field == self._id_field:
+                field = "_id"
+            mongodb_sort.append((field, order))
 
         async def _iter() -> AsyncIterator[Dto]:
             with translate_pymongo_errors():
-                cursor = collection.find(filter=mapping_without_deleted)
+                cursor = self._collection.find(filter=mapping_without_deleted)
                 if sort:
-                    cursor = cursor.sort(sort)
+                    cursor = cursor.sort(mongodb_sort)
                 async for document in cursor.skip(skip).limit(limit):
                     yield document_to_dto(
-                        document, id_field=id_field, dto_model=dto_model
+                        document, id_field=self._id_field, dto_model=self._dto_model
                     )
 
         async def _total_count() -> int:
             with translate_pymongo_errors():
-                return await collection.count_documents(filter=mapping_without_deleted)
+                return await self._collection.count_documents(
+                    filter=mapping_without_deleted
+                )
 
         return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -369,7 +369,13 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         hits = self.find_all(mapping=mapping)
         return await get_single_hit(hits=hits, mapping=mapping)
 
-    async def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[Dto]:
+    async def find_all(
+        self,
+        *,
+        mapping: Mapping[str, Any],
+        skip: int | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
         The values in the mapping are used to filter the resources, these are
@@ -381,16 +387,36 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
             mapping:
                 A mapping where the keys correspond to the names of resource fields
                 and the values correspond to the actual values of the resource fields.
+            skip:
+                Number of matching resources to skip before yielding results.
+                Defaults to None (no skipping).
+            limit:
+                Maximum number of resources to yield. Defaults to None (no limit).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO
             model.
+
+        Raises:
+            InvalidMappingError: If `mapping` doesn't pass validation.
+            ValueError: if `skip` or `limit` are less than 0.
+
+        Raises:
+            InvalidMappingError: If `mapping` doesn't pass validation.
+            ValueError: if `skip` or `limit` are less than 0.
         """
+        skip = skip or 0
+        limit = limit or 0
+        if skip < 0:
+            raise ValueError("skip must be >= 0")
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
         with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping)
+            cursor = self._collection.find(filter=mapping).skip(skip).limit(limit)
 
             async for document in cursor:
                 if document.get("__metadata__", {}).get("deleted", False):

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -43,6 +43,7 @@ from hexkit.protocols.dao import (
     Dao,
     Dto,
     ResourceNotFoundError,
+    SortSpec,
     UniqueConstraintViolationError,
 )
 from hexkit.protocols.daopub import DaoPublisher, DaoPublisherFactoryProtocol
@@ -375,6 +376,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
+        sort: SortSpec | None = None,
     ) -> AsyncIterator[Dto]:
         """Find all resources that match the specified mapping.
 
@@ -392,14 +394,14 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                 Defaults to None (no skipping).
             limit:
                 Maximum number of resources to yield. Defaults to None (no limit).
+            sort:
+                A list of (field_name, sort_order) pairs. sort_order is 1 (ascending)
+                or -1 (descending). Strongly recommended when using skip/limit.
+                Defaults to None (no sort).
 
         Returns:
             An AsyncIterator of hits. All hits are in the form of the respective DTO
             model.
-
-        Raises:
-            InvalidMappingError: If `mapping` doesn't pass validation.
-            ValueError: if `skip` or `limit` are less than 0.
 
         Raises:
             InvalidMappingError: If `mapping` doesn't pass validation.
@@ -415,8 +417,14 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
+        if sort:
+            sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
+
         with translate_pymongo_errors():
-            cursor = self._collection.find(filter=mapping).skip(skip).limit(limit)
+            cursor = self._collection.find(filter=mapping)
+            if sort:
+                cursor = cursor.sort(sort)
+            cursor = cursor.skip(skip).limit(limit)
 
             async for document in cursor:
                 if document.get("__metadata__", {}).get("deleted", False):

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -437,7 +437,7 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
                     )
 
         async def _total_count() -> int:
-            not_deleted = {**mapping, "__metadata__.deleted": {"$ne": True}}
+            not_deleted = {**mapping, "__metadata__.deleted": False}
             with translate_pymongo_errors():
                 return await collection.count_documents(filter=not_deleted)
 

--- a/src/hexkit/providers/mongokafka/provider/daopub.py
+++ b/src/hexkit/providers/mongokafka/provider/daopub.py
@@ -417,6 +417,9 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
         validate_find_mapping(mapping, dto_model=self._dto_model)
         mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
 
+        # Ensure we don't retrieve deleted docs
+        mapping_without_deleted = {**mapping, "__metadata__.deleted": False}
+
         if sort:
             sort = [("_id" if f == self._id_field else f, o) for f, o in sort]
 
@@ -426,20 +429,17 @@ class MongoKafkaDaoPublisher(Generic[Dto]):
 
         async def _iter() -> AsyncIterator[Dto]:
             with translate_pymongo_errors():
-                cursor = collection.find(filter=mapping)
+                cursor = collection.find(filter=mapping_without_deleted)
                 if sort:
                     cursor = cursor.sort(sort)
                 async for document in cursor.skip(skip).limit(limit):
-                    if document.get("__metadata__", {}).get("deleted", False):
-                        continue
                     yield document_to_dto(
                         document, id_field=id_field, dto_model=dto_model
                     )
 
         async def _total_count() -> int:
-            not_deleted = {**mapping, "__metadata__.deleted": False}
             with translate_pymongo_errors():
-                return await collection.count_documents(filter=not_deleted)
+                return await collection.count_documents(filter=mapping_without_deleted)
 
         return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -30,7 +30,6 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
-    SortSpec,
 )
 from hexkit.providers.mongodb.provider import (
     document_to_dto,
@@ -413,7 +412,7 @@ class BaseInMemDao(Generic[DTO]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
-        sort: SortSpec | None = None,
+        sort: list[str] | None = None,
     ) -> "FindResult[DTO]":
         """Find all resources that match the specified mapping."""
         skip = skip or 0
@@ -435,10 +434,12 @@ class BaseInMemDao(Generic[DTO]):
             if self._resource_matches(resource, mapping, predicates)
         ]
 
-        if sort:
-            for field, order in reversed(sort):
-                doc_field = "_id" if field == self._id_field else field
-                matching.sort(key=lambda doc: doc[doc_field], reverse=(order == -1))
+        # Interpret the sorting specification and sort our resources accordingly
+        for spec in reversed(sort or []):
+            desc = spec.startswith("-")
+            field = spec.removeprefix("-")
+            doc_field = "_id" if field == self._id_field else field
+            matching.sort(key=lambda doc: doc[doc_field], reverse=desc)
 
         total = len(matching)
         end = skip + limit if limit else None

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 
 from hexkit.custom_types import ID
 from hexkit.protocols.dao import (
+    FindResult,
     MultipleHitsFoundError,
     NoHitsFoundError,
     ResourceAlreadyExistsError,
@@ -406,14 +407,14 @@ class BaseInMemDao(Generic[DTO]):
                 return False
         return True
 
-    async def find_all(
+    def find_all(
         self,
         *,
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
         sort: SortSpec | None = None,
-    ) -> AsyncIterator[DTO]:
+    ) -> "FindResult[DTO]":
         """Find all resources that match the specified mapping."""
         skip = skip or 0
         limit = limit or 0
@@ -439,9 +440,18 @@ class BaseInMemDao(Generic[DTO]):
                 doc_field = "_id" if field == self._id_field else field
                 matching.sort(key=lambda doc: doc[doc_field], reverse=(order == -1))
 
+        total = len(matching)
         end = skip + limit if limit else None
-        for resource in matching[skip:end]:
-            yield self._deserialize(resource)
+        page = matching[skip:end]
+
+        async def _iter() -> AsyncIterator[DTO]:
+            for resource in page:
+                yield self._deserialize(resource)
+
+        async def _total_count() -> int:
+            return total
+
+        return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 
     async def insert(self, dto: DTO) -> None:
         """Insert a resource.

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -29,6 +29,7 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
+    SortSpec,
 )
 from hexkit.providers.mongodb.provider import (
     document_to_dto,
@@ -411,6 +412,7 @@ class BaseInMemDao(Generic[DTO]):
         mapping: Mapping[str, Any],
         skip: int | None = None,
         limit: int | None = None,
+        sort: SortSpec | None = None,
     ) -> AsyncIterator[DTO]:
         """Find all resources that match the specified mapping."""
         skip = skip or 0
@@ -426,18 +428,20 @@ class BaseInMemDao(Generic[DTO]):
         _mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
         predicates = build_predicates(_mapping) if self._handle_mql else []
 
-        skipped = 0
-        yielded = 0
-        for resource in self.resources.values():
-            if not self._resource_matches(resource, mapping, predicates):
-                continue
-            if skipped < skip:
-                skipped += 1
-                continue
+        matching = [
+            resource
+            for resource in self.resources.values()
+            if self._resource_matches(resource, mapping, predicates)
+        ]
+
+        if sort:
+            for field, order in reversed(sort):
+                doc_field = "_id" if field == self._id_field else field
+                matching.sort(key=lambda doc: doc[doc_field], reverse=(order == -1))
+
+        end = skip + limit if limit else None
+        for resource in matching[skip:end]:
             yield self._deserialize(resource)
-            yielded += 1
-            if limit and yielded >= limit:
-                return
 
     async def insert(self, dto: DTO) -> None:
         """Insert a resource.

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -391,26 +391,53 @@ class BaseInMemDao(Generic[DTO]):
 
         raise MultipleHitsFoundError(mapping=mapping)
 
-    async def find_all(self, *, mapping: Mapping[str, Any]) -> AsyncIterator[DTO]:
+    def _resource_matches(
+        self,
+        resource: Document,
+        mapping: Mapping[str, Any],
+        predicates: list["Predicate"],
+    ) -> bool:
+        """Return whether a resource matches the given mapping or predicates."""
+        if self._handle_mql:
+            return all(p.evaluate(resource=resource) for p in predicates)
+        for key, expected_value in mapping.items():
+            if _get_nested_value(resource, key) != expected_value:
+                return False
+        return True
+
+    async def find_all(
+        self,
+        *,
+        mapping: Mapping[str, Any],
+        skip: int | None = None,
+        limit: int | None = None,
+    ) -> AsyncIterator[DTO]:
         """Find all resources that match the specified mapping."""
+        skip = skip or 0
+        limit = limit or 0
+        if skip < 0:
+            raise ValueError("skip must be >= 0")
+        if limit < 0:
+            raise ValueError("limit must be >= 0")
+
         if "" in mapping:
             raise KeyError("Query mappings can't contain empty-string keys")
 
         _mapping = replace_id_field_in_find_mapping(mapping, self._id_field)
         predicates = build_predicates(_mapping) if self._handle_mql else []
 
+        skipped = 0
+        yielded = 0
         for resource in self.resources.values():
-            if self._handle_mql:
-                matches = all(p.evaluate(resource=resource) for p in predicates)
-            else:
-                matches = True
-                for key, expected_value in mapping.items():
-                    actual_value = _get_nested_value(resource, key)
-                    if actual_value != expected_value:
-                        matches = False
-                        break
-            if matches:
-                yield self._deserialize(resource)
+            if not self._resource_matches(resource, mapping, predicates):
+                continue
+            if skipped < skip:
+                skipped += 1
+                continue
+            yield self._deserialize(resource)
+            yielded += 1
+            if limit and yielded >= limit:
+                return
 
     async def insert(self, dto: DTO) -> None:
         """Insert a resource.

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -416,10 +416,9 @@ class BaseInMemDao(Generic[DTO]):
     ) -> "FindResult[DTO]":
         """Find all resources that match the specified mapping."""
         skip = skip or 0
-        limit = limit or 0
         if skip < 0:
             raise ValueError("skip must be >= 0")
-        if limit < 0:
+        if limit is not None and limit < 0:
             raise ValueError("limit must be >= 0")
 
         if "" in mapping:
@@ -442,15 +441,27 @@ class BaseInMemDao(Generic[DTO]):
             matching.sort(key=lambda doc: doc[doc_field], reverse=desc)
 
         total = len(matching)
-        end = skip + limit if limit else None
+
+        async def _total_count() -> int:
+            return total
+
+        if limit == 0:
+
+            async def _empty_iter() -> AsyncIterator[DTO]:
+                return
+                yield  # makes this an async generator
+
+            return FindResult(
+                results_iterator=_empty_iter(), get_total_count=_total_count
+            )
+
+        # Manually apply pagination params
+        end = (skip + limit) if limit is not None else None
         page = matching[skip:end]
 
         async def _iter() -> AsyncIterator[DTO]:
             for resource in page:
                 yield self._deserialize(resource)
-
-        async def _total_count() -> int:
-            return total
 
         return FindResult(results_iterator=_iter(), get_total_count=_total_count)
 

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -744,3 +744,67 @@ async def test_index_with_string_field(mongodb: MongoDbFixture):
     index = next(iter(indexes.values()))
     # When passing a string, it should create an ascending index
     assert index["key"] == [("field_a", 1)]
+
+
+async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
+    """Test that find_all() respects skip and limit parameters."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    # Insert some test resources into the database
+    resources = [ExampleDto(field_b=i) for i in range(5)]
+    for resource in resources:
+        await dao.insert(resource)
+
+    # Retrieve all items
+    full_set = {hit.id async for hit in dao.find_all(mapping={})}
+    assert len(full_set) == 5
+
+    # skip=2 should reduce results by 2
+    skipped = [hit async for hit in dao.find_all(mapping={}, skip=2)]
+    assert len(skipped) == 3
+    assert all(hit.id in full_set for hit in skipped)
+
+    # limit=3 should cap at 3 results
+    limited = [hit async for hit in dao.find_all(mapping={}, limit=3)]
+    assert len(limited) == 3
+    assert all(hit.id in full_set for hit in limited)
+
+    # skip=1, limit=2 should return exactly 2 results
+    paginated = [hit async for hit in dao.find_all(mapping={}, skip=1, limit=2)]
+    assert len(paginated) == 2
+    assert all(hit.id in full_set for hit in paginated)
+
+    # skip larger than collection size returns nothing
+    over_skip = [hit async for hit in dao.find_all(mapping={}, skip=10)]
+    assert over_skip == []
+
+
+async def test_dao_find_all_pagination_empty_collection(mongodb: MongoDbFixture):
+    """Test find_all() with skip and limit on an empty collection produces no errors."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    results = [hit async for hit in dao.find_all(mapping={}, skip=5, limit=10)]
+    assert results == []
+
+
+async def test_dao_find_all_pagination_negative_values(mongodb: MongoDbFixture):
+    """Test find_all() raises ValueError when skip or limit are negative."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    with pytest.raises(ValueError):
+        [hit async for hit in dao.find_all(mapping={}, skip=-1)]
+
+    with pytest.raises(ValueError):
+        [hit async for hit in dao.find_all(mapping={}, limit=-1)]

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -31,6 +31,7 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
+    SortSpec,
     UniqueConstraintViolationError,
     UUID4Field,
 )
@@ -746,40 +747,59 @@ async def test_index_with_string_field(mongodb: MongoDbFixture):
     assert index["key"] == [("field_a", 1)]
 
 
-async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
-    """Test that find_all() respects skip and limit parameters."""
+async def test_dao_find_all_sort(mongodb: MongoDbFixture):
+    """Test that find_all() respects the sort parameter."""
     dao = await mongodb.dao_factory.get_dao(
         name="example",
         dto_model=ExampleDto,
         id_field="id",
     )
 
-    # Insert some test resources into the database
     resources = [ExampleDto(field_b=i) for i in range(5)]
     for resource in resources:
         await dao.insert(resource)
 
-    # Retrieve all items
-    full_set = {hit.id async for hit in dao.find_all(mapping={})}
-    assert len(full_set) == 5
+    # sort ascending by field_b — results should be ordered 0, 1, 2, 3, 4
+    asc: SortSpec = [("field_b", 1)]
+    asc_results = [hit.field_b async for hit in dao.find_all(mapping={}, sort=asc)]
+    assert asc_results == [0, 1, 2, 3, 4]
 
-    # skip=2 should reduce results by 2
-    skipped = [hit async for hit in dao.find_all(mapping={}, skip=2)]
-    assert len(skipped) == 3
-    assert all(hit.id in full_set for hit in skipped)
+    # sort descending by field_b — results should be ordered 4, 3, 2, 1, 0
+    desc: SortSpec = [("field_b", -1)]
+    desc_results = [hit.field_b async for hit in dao.find_all(mapping={}, sort=desc)]
+    assert desc_results == [4, 3, 2, 1, 0]
 
-    # limit=3 should cap at 3 results
-    limited = [hit async for hit in dao.find_all(mapping={}, limit=3)]
-    assert len(limited) == 3
-    assert all(hit.id in full_set for hit in limited)
 
-    # skip=1, limit=2 should return exactly 2 results
-    paginated = [hit async for hit in dao.find_all(mapping={}, skip=1, limit=2)]
-    assert len(paginated) == 2
-    assert all(hit.id in full_set for hit in paginated)
+async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
+    """Test that find_all() respects skip and limit (with sort for determinism)."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    resources = [ExampleDto(field_b=i) for i in range(5)]
+    for resource in resources:
+        await dao.insert(resource)
+
+    asc: SortSpec = [("field_b", 1)]
+
+    # skip=2 returns items with field_b in [2, 3, 4]
+    skipped = [hit.field_b async for hit in dao.find_all(mapping={}, skip=2, sort=asc)]
+    assert skipped == [2, 3, 4]
+
+    # limit=3 returns items with field_b in [0, 1, 2]
+    limited = [hit.field_b async for hit in dao.find_all(mapping={}, limit=3, sort=asc)]
+    assert limited == [0, 1, 2]
+
+    # skip=1, limit=2 returns items with field_b in [1, 2]
+    paginated = [
+        hit.field_b async for hit in dao.find_all(mapping={}, skip=1, limit=2, sort=asc)
+    ]
+    assert paginated == [1, 2]
 
     # skip larger than collection size returns nothing
-    over_skip = [hit async for hit in dao.find_all(mapping={}, skip=10)]
+    over_skip = [hit async for hit in dao.find_all(mapping={}, skip=10, sort=asc)]
     assert over_skip == []
 
 

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -828,3 +828,131 @@ async def test_dao_find_all_pagination_negative_values(mongodb: MongoDbFixture):
 
     with pytest.raises(ValueError):
         [hit async for hit in dao.find_all(mapping={}, limit=-1)]
+
+
+async def test_dao_find_all_sort_by_id_field(mongodb: MongoDbFixture):
+    """Test that sorting correctly substitutes the id field with "_id"."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDtoWithIntID,
+        id_field="custom_id",
+    )
+
+    for custom_id in [30, 10, 20]:
+        await dao.insert(ExampleDtoWithIntID(custom_id=custom_id))
+
+    asc: SortSpec = [("custom_id", 1)]
+    asc_results = [hit.custom_id async for hit in dao.find_all(mapping={}, sort=asc)]
+    assert asc_results == [10, 20, 30]
+
+    desc: SortSpec = [("custom_id", -1)]
+    desc_results = [hit.custom_id async for hit in dao.find_all(mapping={}, sort=desc)]
+    assert desc_results == [30, 20, 10]
+
+
+async def test_dao_find_all_sort_compound(mongodb: MongoDbFixture):
+    """Test that compound sort (multiple fields) works."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    await dao.insert(ExampleDto(field_a="cherry", field_b=1))
+    await dao.insert(ExampleDto(field_a="banana", field_b=2))
+    await dao.insert(ExampleDto(field_a="apple", field_b=2))
+    await dao.insert(ExampleDto(field_a="date", field_b=2))
+
+    # Primary: field_b asc; secondary: field_a asc (tiebreak within field_b=2 group)
+    compound_sort: SortSpec = [("field_b", 1), ("field_a", 1)]
+    results = [
+        hit.field_a async for hit in dao.find_all(mapping={}, sort=compound_sort)
+    ]
+    assert results == ["cherry", "apple", "banana", "date"]
+
+
+async def test_dao_find_all_total_count_with_filter(mongodb: MongoDbFixture):
+    """Make sure that total_count() reflects the filtered match count, not the total
+    collection size.
+    """
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    # Insert some docs with two different values for field_b
+    for field_a in ["a", "b", "c"]:
+        await dao.insert(ExampleDto(field_a=field_a, field_b=10))
+    for field_a in ["d", "e"]:
+        await dao.insert(ExampleDto(field_a=field_a, field_b=20))
+
+    asc: SortSpec = [("field_a", 1)]
+    result = dao.find_all(mapping={"field_b": 10}, skip=1, limit=1, sort=asc)
+    page = [hit.field_a async for hit in result]
+    assert page == ["b"]
+
+    assert await result.total_count() == 3
+
+
+async def test_dao_find_all_total_count_before_iteration(mongodb: MongoDbFixture):
+    """Test that total_count() works correctly when called before consuming any results."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    for _ in range(3):
+        await dao.insert(ExampleDto())
+
+    result = dao.find_all(mapping={}, skip=1, limit=1)
+    total = await result.total_count()
+    assert total == 3
+
+    page = [hit async for hit in result]
+    assert len(page) == 1
+
+
+async def test_dao_find_all_total_count_empty_filter_result(mongodb: MongoDbFixture):
+    """Test that total_count() returns 0 when no documents match the mapping."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    await dao.insert(ExampleDto())
+    await dao.insert(ExampleDto())
+
+    result = dao.find_all(mapping={"field_b": 99999})
+    page = [hit async for hit in result]
+    assert page == []
+
+    total = await result.total_count()
+    assert total == 0
+
+
+async def test_dao_find_all_total_count(mongodb: MongoDbFixture):
+    """Test that total_count() returns the full matching count regardless of skip/limit."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    resources = [ExampleDto(field_b=i) for i in range(5)]
+    for resource in resources:
+        await dao.insert(resource)
+
+    asc: SortSpec = [("field_b", 1)]
+    result = dao.find_all(mapping={}, skip=2, limit=2, sort=asc)
+    page = [hit.field_b async for hit in result]
+    assert page == [2, 3]
+
+    total = await result.total_count()
+    assert total == 5
+
+    # calling total_count() a second time uses the cached value
+    total_again = await result.total_count()
+    assert total_again == 5

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -804,6 +804,23 @@ async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
     assert over_skip == []
 
 
+async def test_dao_find_all_limit_zero(mongodb: MongoDbFixture):
+    """Test that limit=0 returns an empty iterator but total_count still works."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    for _ in range(3):
+        await dao.insert(ExampleDto())
+
+    result = dao.find_all(mapping={}, limit=0)
+    page = [hit async for hit in result]
+    assert page == []
+    assert await result.total_count() == 3
+
+
 async def test_dao_find_all_pagination_empty_collection(mongodb: MongoDbFixture):
     """Test find_all() with skip and limit on an empty collection produces no errors."""
     dao = await mongodb.dao_factory.get_dao(

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -31,7 +31,6 @@ from hexkit.protocols.dao import (
     NoHitsFoundError,
     ResourceAlreadyExistsError,
     ResourceNotFoundError,
-    SortSpec,
     UniqueConstraintViolationError,
     UUID4Field,
 )
@@ -760,13 +759,15 @@ async def test_dao_find_all_sort(mongodb: MongoDbFixture):
         await dao.insert(resource)
 
     # sort ascending by field_b — results should be ordered 0, 1, 2, 3, 4
-    asc: SortSpec = [("field_b", 1)]
-    asc_results = [hit.field_b async for hit in dao.find_all(mapping={}, sort=asc)]
+    asc_results = [
+        hit.field_b async for hit in dao.find_all(mapping={}, sort=["field_b"])
+    ]
     assert asc_results == [0, 1, 2, 3, 4]
 
     # sort descending by field_b — results should be ordered 4, 3, 2, 1, 0
-    desc: SortSpec = [("field_b", -1)]
-    desc_results = [hit.field_b async for hit in dao.find_all(mapping={}, sort=desc)]
+    desc_results = [
+        hit.field_b async for hit in dao.find_all(mapping={}, sort=["-field_b"])
+    ]
     assert desc_results == [4, 3, 2, 1, 0]
 
 
@@ -782,7 +783,7 @@ async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
     for resource in resources:
         await dao.insert(resource)
 
-    asc: SortSpec = [("field_b", 1)]
+    asc = ["field_b"]
 
     # skip=2 returns items with field_b in [2, 3, 4]
     skipped = [hit.field_b async for hit in dao.find_all(mapping={}, skip=2, sort=asc)]
@@ -841,11 +842,11 @@ async def test_dao_find_all_sort_by_id_field(mongodb: MongoDbFixture):
     for custom_id in [30, 10, 20]:
         await dao.insert(ExampleDtoWithIntID(custom_id=custom_id))
 
-    asc: SortSpec = [("custom_id", 1)]
+    asc = ["custom_id"]
     asc_results = [hit.custom_id async for hit in dao.find_all(mapping={}, sort=asc)]
     assert asc_results == [10, 20, 30]
 
-    desc: SortSpec = [("custom_id", -1)]
+    desc = ["-custom_id"]
     desc_results = [hit.custom_id async for hit in dao.find_all(mapping={}, sort=desc)]
     assert desc_results == [30, 20, 10]
 
@@ -864,7 +865,7 @@ async def test_dao_find_all_sort_compound(mongodb: MongoDbFixture):
     await dao.insert(ExampleDto(field_a="date", field_b=2))
 
     # Primary: field_b asc; secondary: field_a asc (tiebreak within field_b=2 group)
-    compound_sort: SortSpec = [("field_b", 1), ("field_a", 1)]
+    compound_sort = ["field_b", "field_a"]
     results = [
         hit.field_a async for hit in dao.find_all(mapping={}, sort=compound_sort)
     ]
@@ -887,8 +888,7 @@ async def test_dao_find_all_total_count_with_filter(mongodb: MongoDbFixture):
     for field_a in ["d", "e"]:
         await dao.insert(ExampleDto(field_a=field_a, field_b=20))
 
-    asc: SortSpec = [("field_a", 1)]
-    result = dao.find_all(mapping={"field_b": 10}, skip=1, limit=1, sort=asc)
+    result = dao.find_all(mapping={"field_b": 10}, skip=1, limit=1, sort=["field_a"])
     page = [hit.field_a async for hit in result]
     assert page == ["b"]
 
@@ -945,8 +945,7 @@ async def test_dao_find_all_total_count(mongodb: MongoDbFixture):
     for resource in resources:
         await dao.insert(resource)
 
-    asc: SortSpec = [("field_b", 1)]
-    result = dao.find_all(mapping={}, skip=2, limit=2, sort=asc)
+    result = dao.find_all(mapping={}, skip=2, limit=2, sort=["field_b"])
     page = [hit.field_b async for hit in result]
     assert page == [2, 3]
 

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -995,8 +995,6 @@ async def test_find_all_total_count_excludes_soft_deleted(
         total = await result.total_count()
         assert total == 2
 
-
-# @pytest.mark.parametrize("skip")
 @pytest.mark.parametrize("delete_metadata", [True, False])
 async def test_pagination_against_flaky_metadata(
     mongo_kafka: MongoKafkaFixture, delete_metadata: bool

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -963,3 +963,34 @@ async def test_unique_index_error_handling(mongo_kafka: MongoKafkaFixture):
 
         with pytest.raises(UniqueConstraintViolationError):
             await dao.upsert(dto5)
+
+
+async def test_find_all_total_count_excludes_soft_deleted(
+    mongo_kafka: MongoKafkaFixture,
+):
+    """Verify that total_count() doesn't include deleted outbox documents."""
+    async with MongoKafkaDaoPublisherFactory.construct(
+        config=mongo_kafka.config
+    ) as factory:
+        dao = await factory.get_dao(
+            name="example",
+            dto_model=ExampleDto,
+            id_field="id",
+            dto_to_event=lambda dto: dto.model_dump(),
+            event_topic=EXAMPLE_TOPIC,
+        )
+
+        # Add four docs and then delete two of them (the 'dead' ones)
+        live1, live2, dead1, dead2 = (ExampleDto() for _ in range(4))
+        for dto in (live1, live2, dead1, dead2):
+            await dao.insert(dto)
+        await dao.delete(dead1.id)
+        await dao.delete(dead2.id)
+
+        # Run a query and make sure total_count() is 2
+        result = dao.find_all(mapping={})
+        page = [hit async for hit in result]
+        assert len(page) == 2
+
+        total = await result.total_count()
+        assert total == 2

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -994,3 +994,50 @@ async def test_find_all_total_count_excludes_soft_deleted(
 
         total = await result.total_count()
         assert total == 2
+
+
+# @pytest.mark.parametrize("skip")
+@pytest.mark.parametrize("delete_metadata", [True, False])
+async def test_pagination_against_flaky_metadata(
+    mongo_kafka: MongoKafkaFixture, delete_metadata: bool
+):
+    """Test pagination when many outbox documents have been deleted or lack metadata."""
+    async with MongoKafkaDaoPublisherFactory.construct(
+        config=mongo_kafka.config
+    ) as factory:
+        dao = await factory.get_dao(
+            name="example",
+            dto_model=ExampleDto,
+            id_field="id",
+            dto_to_event=lambda dto: dto.model_dump(),
+            event_topic=EXAMPLE_TOPIC,
+        )
+
+        # Add four docs and then delete all of them
+        docs = [ExampleDto() for _ in range(4)]
+        for dto in docs:
+            await dao.insert(dto)
+            await dao.delete(dto.id)
+
+        if delete_metadata:
+            db = mongo_kafka.mongodb.client.get_database(mongo_kafka.config.db_name)
+            collection = db["example"]
+            retrieved_docs = collection.find().to_list()
+            assert len(docs) == 4
+            for doc in retrieved_docs:
+                del doc["__metadata__"]
+                collection.replace_one({"_id": doc["_id"]}, doc)
+
+        # Insert a document that will be last when sorted
+        live_id = uuid.UUID("99999999-9999-4999-9999-999999999999")
+        live_doc = ExampleDto(id=live_id)
+        await dao.insert(live_doc)
+
+        # Now find_all but with limit set to 4
+        #  If filtering is not done properly, this would return an empty list
+        results_limit = [x async for x in dao.find_all(mapping={}, skip=None, limit=4)]
+        assert results_limit == [live_doc]
+
+        # Check that using skip=1 and no limit returns an empty list
+        results_skip = [x async for x in dao.find_all(mapping={}, skip=1)]
+        assert results_skip == []

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -995,6 +995,7 @@ async def test_find_all_total_count_excludes_soft_deleted(
         total = await result.total_count()
         assert total == 2
 
+
 @pytest.mark.parametrize("delete_metadata", [True, False])
 async def test_pagination_against_flaky_metadata(
     mongo_kafka: MongoKafkaFixture, delete_metadata: bool

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -1021,7 +1021,7 @@ async def test_pagination_against_flaky_metadata(
             db = mongo_kafka.mongodb.client.get_database(mongo_kafka.config.db_name)
             collection = db["example"]
             retrieved_docs = collection.find().to_list()
-            assert len(docs) == 4
+            assert len(retrieved_docs) == 4
             for doc in retrieved_docs:
                 del doc["__metadata__"]
                 collection.replace_one({"_id": doc["_id"]}, doc)

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -559,3 +559,104 @@ async def test_find_all_pagination_negative_values():
 
     with pytest.raises(ValueError):
         [x async for x in dao.find_all(mapping={}, skip=-1, limit=-1)]
+
+
+async def test_find_all_sort_by_id_field():
+    """Test that "_id" is used when sorting by the ID field.
+
+    DaoClass uses 'title' as its id_field. Documents are stored with '_id' as
+    the key internally, so sort=[("title", ...)] must translate to sorting on '_id'.
+    """
+    dao = DaoClass()
+    await dao.insert(InventoryItem(title="Cherry", count=1))
+    await dao.insert(InventoryItem(title="Apple", count=2))
+    await dao.insert(InventoryItem(title="Banana", count=3))
+
+    asc_sort: SortSpec = [("title", 1)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=asc_sort)]
+    assert results == ["Apple", "Banana", "Cherry"]
+
+    desc_sort: SortSpec = [("title", -1)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=desc_sort)]
+    assert results == ["Cherry", "Banana", "Apple"]
+
+
+async def test_find_all_sort_compound():
+    """Ensure compound sort (multiple fields) produces correct stable ordering."""
+    dao = DaoClass()
+    await dao.insert(InventoryItem(title="Cherry", count=1))
+    await dao.insert(InventoryItem(title="Banana", count=2))
+    await dao.insert(InventoryItem(title="Apple", count=2))
+    await dao.insert(InventoryItem(title="Date", count=2))
+
+    # Primary: count asc; secondary: title asc (tiebreak within count=2 group)
+    compound_sort: SortSpec = [("count", 1), ("title", 1)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=compound_sort)]
+    assert results == ["Cherry", "Apple", "Banana", "Date"]
+
+
+async def test_find_all_total_count_with_filter():
+    """Make sure that total_count() reflects the filtered match count, not
+    the total collection size.
+    """
+    dao = DaoClass()
+    for title in ["Apple", "Banana", "Cherry"]:
+        await dao.insert(InventoryItem(title=title, count=1))
+    for title in ["Date", "Elderberry"]:
+        await dao.insert(InventoryItem(title=title, count=2))
+
+    asc_sort: SortSpec = [("title", 1)]
+    result = dao.find_all(mapping={"count": 1}, skip=1, limit=1, sort=asc_sort)
+    page = [x.title async for x in result]
+    assert page == ["Banana"]
+
+    total = await result.total_count()
+    assert total == 3  # 3 match the filter, not 5
+
+
+async def test_find_all_total_count_before_iteration():
+    """Verify total_count() works correctly when called before consuming any results."""
+    dao = DaoClass()
+    for title in ["Apple", "Banana", "Cherry"]:
+        await dao.insert(InventoryItem(title=title, count=1))
+
+    result = dao.find_all(mapping={}, skip=1, limit=1)
+    total = await result.total_count()
+    assert total == 3
+
+    page = [x async for x in result]
+    assert len(page) == 1
+
+
+async def test_find_all_total_count_empty_filter_result():
+    """Test that total_count() returns 0 when no documents match the mapping."""
+    dao = DaoClass()
+    await dao.insert(InventoryItem(title="Apple", count=1))
+    await dao.insert(InventoryItem(title="Banana", count=1))
+
+    result = dao.find_all(mapping={"count": 999})
+    page = [x async for x in result]
+    assert page == []
+
+    total = await result.total_count()
+    assert total == 0
+
+
+async def test_find_all_total_count():
+    """Test that total_count() returns the full matching count regardless of skip/limit."""
+    dao = DaoClass()
+    titles = ["Apple", "Banana", "Cherry", "Date", "Elderberry"]
+    for title in titles:
+        await dao.insert(InventoryItem(title=title, count=1))
+
+    asc_sort: SortSpec = [("title", 1)]
+    result = dao.find_all(mapping={}, skip=2, limit=2, sort=asc_sort)
+    page = [x.title async for x in result]
+    assert page == ["Cherry", "Date"]
+
+    total = await result.total_count()
+    assert total == 5
+
+    # calling total_count() a second time uses the cached value
+    total_again = await result.total_count()
+    assert total_again == 5

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -20,7 +20,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError, SortSpec
+from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError
 from hexkit.providers.testing import MockDAOEmptyError, new_mock_dao_class
 from hexkit.providers.testing.dao import (
     ComparisonPredicate,
@@ -494,15 +494,15 @@ async def test_find_all_sort():
     await dao.insert(InventoryItem(title="Cherry", count=1))
 
     # sort ascending by title
-    results = [x.title async for x in dao.find_all(mapping={}, sort=[("title", 1)])]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["title"])]
     assert results == ["Apple", "Banana", "Cherry"]
 
     # sort descending by title
-    results = [x.title async for x in dao.find_all(mapping={}, sort=[("title", -1)])]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["-title"])]
     assert results == ["Cherry", "Banana", "Apple"]
 
     # sort ascending by count
-    results = [x.title async for x in dao.find_all(mapping={}, sort=[("count", 1)])]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["count"])]
     assert results == ["Cherry", "Banana", "Apple"]
 
 
@@ -513,7 +513,7 @@ async def test_find_all_pagination():
     for title in titles:
         await dao.insert(InventoryItem(title=title, count=1))
 
-    asc_sort: SortSpec = [("title", 1)]
+    asc_sort = ["title"]
 
     # skip=2 returns items starting from index 2
     results = [x.title async for x in dao.find_all(mapping={}, skip=2, sort=asc_sort)]
@@ -572,12 +572,10 @@ async def test_find_all_sort_by_id_field():
     await dao.insert(InventoryItem(title="Apple", count=2))
     await dao.insert(InventoryItem(title="Banana", count=3))
 
-    asc_sort: SortSpec = [("title", 1)]
-    results = [x.title async for x in dao.find_all(mapping={}, sort=asc_sort)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["title"])]
     assert results == ["Apple", "Banana", "Cherry"]
 
-    desc_sort: SortSpec = [("title", -1)]
-    results = [x.title async for x in dao.find_all(mapping={}, sort=desc_sort)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["-title"])]
     assert results == ["Cherry", "Banana", "Apple"]
 
 
@@ -590,8 +588,7 @@ async def test_find_all_sort_compound():
     await dao.insert(InventoryItem(title="Date", count=2))
 
     # Primary: count asc; secondary: title asc (tiebreak within count=2 group)
-    compound_sort: SortSpec = [("count", 1), ("title", 1)]
-    results = [x.title async for x in dao.find_all(mapping={}, sort=compound_sort)]
+    results = [x.title async for x in dao.find_all(mapping={}, sort=["count", "title"])]
     assert results == ["Cherry", "Apple", "Banana", "Date"]
 
 
@@ -605,8 +602,7 @@ async def test_find_all_total_count_with_filter():
     for title in ["Date", "Elderberry"]:
         await dao.insert(InventoryItem(title=title, count=2))
 
-    asc_sort: SortSpec = [("title", 1)]
-    result = dao.find_all(mapping={"count": 1}, skip=1, limit=1, sort=asc_sort)
+    result = dao.find_all(mapping={"count": 1}, skip=1, limit=1, sort=["title"])
     page = [x.title async for x in result]
     assert page == ["Banana"]
 
@@ -649,8 +645,7 @@ async def test_find_all_total_count():
     for title in titles:
         await dao.insert(InventoryItem(title=title, count=1))
 
-    asc_sort: SortSpec = [("title", 1)]
-    result = dao.find_all(mapping={}, skip=2, limit=2, sort=asc_sort)
+    result = dao.find_all(mapping={}, skip=2, limit=2, sort=["title"])
     page = [x.title async for x in result]
     assert page == ["Cherry", "Date"]
 

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -547,7 +547,7 @@ async def test_find_all_limit_zero_and_none():
 
     result = dao.find_all(mapping={}, limit=0)
     page = {x.title async for x in result}
-    assert page == []
+    assert page == {}
     assert await result.total_count() == 3
 
     result = dao.find_all(mapping={}, limit=None)

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -533,11 +533,27 @@ async def test_find_all_pagination():
     results = [x.title async for x in dao.find_all(mapping={}, skip=10, sort=asc_sort)]
     assert results == []
 
-    # skip=0, limit=0 behaves like no pagination (limit=0 means no limit)
-    results = [
-        x.title async for x in dao.find_all(mapping={}, skip=0, limit=0, sort=asc_sort)
-    ]
-    assert results == titles
+
+async def test_find_all_limit_zero_and_none():
+    """Test limit=0 and limit=None, but that total_count works either way.
+
+    When limit=0, no results should be returned.
+    When limit=None, all results should be returned.
+    """
+    dao = DaoClass()
+    titles = {"Apple", "Banana", "Cherry"}
+    for title in titles:
+        await dao.insert(InventoryItem(title=title, count=1))
+
+    result = dao.find_all(mapping={}, limit=0)
+    page = {x.title async for x in result}
+    assert page == []
+    assert await result.total_count() == 3
+
+    result = dao.find_all(mapping={}, limit=None)
+    page = {x.title async for x in result}
+    assert page == titles
+    assert await result.total_count() == 3
 
 
 async def test_find_all_pagination_empty_collection():

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -484,3 +484,52 @@ async def test_fields_with_dollar_sign():
     mapping = {"$bogus": 8}
     with pytest.raises(MQLError):
         _ = build_predicates(mapping)
+
+
+async def test_find_all_pagination():
+    """Test find_all() with skip and/or limit parameters."""
+    dao = DaoClass()
+    titles = ["Apple", "Banana", "Cherry", "Date", "Elderberry"]
+    for title in titles:
+        await dao.insert(InventoryItem(title=title, count=1))
+
+    # skip=2 returns items starting from index 2 (insertion order is preserved)
+    results = [x.title async for x in dao.find_all(mapping={}, skip=2)]
+    assert results == ["Cherry", "Date", "Elderberry"]
+
+    # limit=3 returns first 3 items
+    results = [x.title async for x in dao.find_all(mapping={}, limit=3)]
+    assert results == ["Apple", "Banana", "Cherry"]
+
+    # skip=1, limit=2 returns banana and cherry
+    results = [x.title async for x in dao.find_all(mapping={}, skip=1, limit=2)]
+    assert results == ["Banana", "Cherry"]
+
+    # skip larger than collection size returns no results
+    results = [x.title async for x in dao.find_all(mapping={}, skip=10)]
+    assert results == []
+
+    # skip=0 and limit=0 behaves like no pagination (limit=0 means no limit in MongoDB)
+    results = [x.title async for x in dao.find_all(mapping={}, skip=0, limit=0)]
+    assert results == titles
+
+
+async def test_find_all_pagination_empty_collection():
+    """Test find_all() with skip and limit on an empty collection produces no errors."""
+    dao = DaoClass()
+    results = [x async for x in dao.find_all(mapping={}, skip=5, limit=10)]
+    assert results == []
+
+
+async def test_find_all_pagination_negative_values():
+    """Test find_all() raises ValueError when skip or limit are negative."""
+    dao = DaoClass()
+
+    with pytest.raises(ValueError):
+        [x async for x in dao.find_all(mapping={}, skip=-1)]
+
+    with pytest.raises(ValueError):
+        [x async for x in dao.find_all(mapping={}, limit=-1)]
+
+    with pytest.raises(ValueError):
+        [x async for x in dao.find_all(mapping={}, skip=-1, limit=-1)]

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -547,7 +547,7 @@ async def test_find_all_limit_zero_and_none():
 
     result = dao.find_all(mapping={}, limit=0)
     page = {x.title async for x in result}
-    assert page == {}
+    assert page == set()
     assert await result.total_count() == 3
 
     result = dao.find_all(mapping={}, limit=None)

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -20,7 +20,7 @@ from typing import Any
 import pytest
 from pydantic import BaseModel
 
-from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError
+from hexkit.protocols.dao import NoHitsFoundError, ResourceNotFoundError, SortSpec
 from hexkit.providers.testing import MockDAOEmptyError, new_mock_dao_class
 from hexkit.providers.testing.dao import (
     ComparisonPredicate,
@@ -486,31 +486,57 @@ async def test_fields_with_dollar_sign():
         _ = build_predicates(mapping)
 
 
+async def test_find_all_sort():
+    """Test find_all() with the sort parameter."""
+    dao = DaoClass()
+    await dao.insert(InventoryItem(title="Banana", count=2))
+    await dao.insert(InventoryItem(title="Apple", count=3))
+    await dao.insert(InventoryItem(title="Cherry", count=1))
+
+    # sort ascending by title
+    results = [x.title async for x in dao.find_all(mapping={}, sort=[("title", 1)])]
+    assert results == ["Apple", "Banana", "Cherry"]
+
+    # sort descending by title
+    results = [x.title async for x in dao.find_all(mapping={}, sort=[("title", -1)])]
+    assert results == ["Cherry", "Banana", "Apple"]
+
+    # sort ascending by count
+    results = [x.title async for x in dao.find_all(mapping={}, sort=[("count", 1)])]
+    assert results == ["Cherry", "Banana", "Apple"]
+
+
 async def test_find_all_pagination():
-    """Test find_all() with skip and/or limit parameters."""
+    """Test find_all() with skip and/or limit (with sort for deterministic ordering)."""
     dao = DaoClass()
     titles = ["Apple", "Banana", "Cherry", "Date", "Elderberry"]
     for title in titles:
         await dao.insert(InventoryItem(title=title, count=1))
 
-    # skip=2 returns items starting from index 2 (insertion order is preserved)
-    results = [x.title async for x in dao.find_all(mapping={}, skip=2)]
+    asc_sort: SortSpec = [("title", 1)]
+
+    # skip=2 returns items starting from index 2
+    results = [x.title async for x in dao.find_all(mapping={}, skip=2, sort=asc_sort)]
     assert results == ["Cherry", "Date", "Elderberry"]
 
     # limit=3 returns first 3 items
-    results = [x.title async for x in dao.find_all(mapping={}, limit=3)]
+    results = [x.title async for x in dao.find_all(mapping={}, limit=3, sort=asc_sort)]
     assert results == ["Apple", "Banana", "Cherry"]
 
-    # skip=1, limit=2 returns banana and cherry
-    results = [x.title async for x in dao.find_all(mapping={}, skip=1, limit=2)]
+    # skip=1, limit=2 returns the window [1, 3)
+    results = [
+        x.title async for x in dao.find_all(mapping={}, skip=1, limit=2, sort=asc_sort)
+    ]
     assert results == ["Banana", "Cherry"]
 
     # skip larger than collection size returns no results
-    results = [x.title async for x in dao.find_all(mapping={}, skip=10)]
+    results = [x.title async for x in dao.find_all(mapping={}, skip=10, sort=asc_sort)]
     assert results == []
 
-    # skip=0 and limit=0 behaves like no pagination (limit=0 means no limit in MongoDB)
-    results = [x.title async for x in dao.find_all(mapping={}, skip=0, limit=0)]
+    # skip=0, limit=0 behaves like no pagination (limit=0 means no limit)
+    results = [
+        x.title async for x in dao.find_all(mapping={}, skip=0, limit=0, sort=asc_sort)
+    ]
     assert results == titles
 
 


### PR DESCRIPTION
The DAO protocol and providers now expose pagination parameters in `find_all()`: `sort`, `skip`, and `limit`. Additionally, the result of `find_all()` exposes a `.total_count()` method that returns the total number of items matching the filter regardless of skip/limit. Together, these should enable both offset-based and cursor-based pagination.

Bumps the version to `8.3.0`