### PR TITLE
Fix InMemDao sorting for nested fields (GSI-2454)

### DIFF
--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -441,11 +441,10 @@ class BaseInMemDao(Generic[DTO]):
         for spec in reversed(sort or []):
             desc = spec.startswith("-")
             field = spec.removeprefix("-")
-            doc_field = (
-                field.replace(self._id_field, "_id")
-                if field.startswith(self._id_field)
-                else field
-            )
+            if field == self._id_field or field.startswith(f"{self._id_field}."):
+                doc_field = "_id" + field[len(self._id_field) :]
+            else:
+                doc_field = field
 
             # Handle nested fields
             if "." in doc_field:

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -88,6 +88,18 @@ def _get_nested_value(resource: Document, field_path: str) -> Any:
     return value
 
 
+def _sort_key(resource: Document, *, field_path: str) -> tuple[bool, Any]:
+    """Build a sort key for a (possibly nested) field path of a resource.
+
+    Missing values (None) are grouped together and sorted ahead of present values,
+    mirroring MongoDB's handling of missing/null fields. The leading boolean keeps
+    None values from being compared against present values (or one another), which
+    would otherwise raise a TypeError.
+    """
+    value = _get_nested_value(resource, field_path)
+    return (value is not None, value if value is not None else 0)
+
+
 class Predicate(Protocol):
     def evaluate(self, resource: dict[str, Any]) -> bool:
         """Determine if the supplied dict value satisfies the predicate."""
@@ -410,7 +422,7 @@ class BaseInMemDao(Generic[DTO]):
                 return False
         return True
 
-    def find_all(  # noqa: C901
+    def find_all(
         self,
         *,
         mapping: Mapping[str, Any],
@@ -441,17 +453,12 @@ class BaseInMemDao(Generic[DTO]):
         for spec in reversed(sort or []):
             desc = spec.startswith("-")
             field = spec.removeprefix("-")
-            if field == self._id_field or field.startswith(f"{self._id_field}."):
-                doc_field = "_id" + field[len(self._id_field) :]
-            else:
-                doc_field = field
-
-            # Handle nested fields
-            if "." in doc_field:
-                nested_sort_key = partial(_get_nested_value, field_path=doc_field)
-                matching.sort(key=nested_sort_key, reverse=desc)
-            else:
-                matching.sort(key=lambda doc: doc[doc_field], reverse=desc)
+            # Only the exact ID field is translated to the internal "_id" field, matching
+            # the MongoDB provider. Other fields (including nested sub-fields of the ID,
+            # which MongoDB cannot sort by) are looked up as-is and resolve to None when
+            # absent, sorting consistently rather than raising - again like MongoDB.
+            doc_field = "_id" if field == self._id_field else field
+            matching.sort(key=partial(_sort_key, field_path=doc_field), reverse=desc)
 
         total = len(matching)
 

--- a/src/hexkit/providers/testing/dao.py
+++ b/src/hexkit/providers/testing/dao.py
@@ -18,6 +18,7 @@
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import AbstractAsyncContextManager, suppress
 from copy import deepcopy
+from functools import partial
 from typing import Any, Generic, Protocol, TypeVar
 from unittest.mock import AsyncMock
 
@@ -409,7 +410,7 @@ class BaseInMemDao(Generic[DTO]):
                 return False
         return True
 
-    def find_all(
+    def find_all(  # noqa: C901
         self,
         *,
         mapping: Mapping[str, Any],
@@ -440,8 +441,18 @@ class BaseInMemDao(Generic[DTO]):
         for spec in reversed(sort or []):
             desc = spec.startswith("-")
             field = spec.removeprefix("-")
-            doc_field = "_id" if field == self._id_field else field
-            matching.sort(key=lambda doc: doc[doc_field], reverse=desc)
+            doc_field = (
+                field.replace(self._id_field, "_id")
+                if field.startswith(self._id_field)
+                else field
+            )
+
+            # Handle nested fields
+            if "." in doc_field:
+                nested_sort_key = partial(_get_nested_value, field_path=doc_field)
+                matching.sort(key=nested_sort_key, reverse=desc)
+            else:
+                matching.sort(key=lambda doc: doc[doc_field], reverse=desc)
 
         total = len(matching)
 

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -671,3 +671,41 @@ async def test_find_all_total_count():
     # calling total_count() a second time uses the cached value
     total_again = await result.total_count()
     assert total_again == 5
+
+
+@pytest.mark.parametrize("id_field", ["id", "inner"])
+async def test_nested_sort_in_find_all(id_field: str):
+    """Test to make sure `sort` works correctly in find_all() when the field is nested.
+
+    Also tests that it works when the specified nested sort field starts with the ID
+    field of the DTO. For that to work, had to define a hash method on the InnerDto
+    model since it is stored as a dict key.
+    """
+
+    class InnerDto(BaseModel):
+        def __hash__(self) -> int:
+            return self.x
+
+        x: int
+
+    class OuterDto(BaseModel):
+        id: int
+        inner: InnerDto
+
+    OuterDtoDao = new_mock_dao_class(dto_model=OuterDto, id_field=id_field)  # noqa: N806
+    dao = OuterDtoDao()
+
+    dtos = [
+        OuterDto(id=1, inner=InnerDto(x=3)),
+        OuterDto(id=2, inner=InnerDto(x=1)),
+        OuterDto(id=3, inner=InnerDto(x=7)),
+    ]
+
+    for dto in dtos:
+        await dao.insert(dto)
+
+    # First retrieve results and make sure they're returned in the order defined above
+    assert [x.id async for x in dao.find_all(mapping={})] == [1, 2, 3]
+
+    # Now apply sorting on the nested field
+    assert [x.id async for x in dao.find_all(mapping={}, sort=["inner.x"])] == [2, 1, 3]

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -673,26 +673,17 @@ async def test_find_all_total_count():
     assert total_again == 5
 
 
-@pytest.mark.parametrize("id_field", ["id", "inner"])
-async def test_nested_sort_in_find_all(id_field: str):
-    """Test to make sure `sort` works correctly in find_all() when the field is nested.
-
-    Also tests that it works when the specified nested sort field starts with the ID
-    field of the DTO. For that to work, had to define a hash method on the InnerDto
-    model since it is stored as a dict key.
-    """
+async def test_nested_sort_in_find_all():
+    """Test that `sort` works correctly in find_all() when the field is nested."""
 
     class InnerDto(BaseModel):
-        def __hash__(self) -> int:
-            return self.x
-
         x: int
 
     class OuterDto(BaseModel):
         id: int
         inner: InnerDto
 
-    OuterDtoDao = new_mock_dao_class(dto_model=OuterDto, id_field=id_field)  # noqa: N806
+    OuterDtoDao = new_mock_dao_class(dto_model=OuterDto, id_field="id")  # noqa: N806
     dao = OuterDtoDao()
 
     dtos = [
@@ -704,8 +695,115 @@ async def test_nested_sort_in_find_all(id_field: str):
     for dto in dtos:
         await dao.insert(dto)
 
-    # First retrieve results and make sure they're returned in the order defined above
-    assert [x.id async for x in dao.find_all(mapping={})] == [1, 2, 3]
+    find_all = dao.find_all
 
-    # Now apply sorting on the nested field
-    assert [x.id async for x in dao.find_all(mapping={}, sort=["inner.x"])] == [2, 1, 3]
+    # First retrieve results and make sure they're returned in the order defined above
+    assert [x.id async for x in find_all(mapping={})] == [1, 2, 3]
+
+    # Now apply ascending and descending sorting on the nested field
+    assert [x.id async for x in find_all(mapping={}, sort=["inner.x"])] == [2, 1, 3]
+    assert [x.id async for x in find_all(mapping={}, sort=["-inner.x"])] == [3, 1, 2]
+
+
+async def test_sort_field_starting_with_id_field():
+    """Test that only the exact ID field is translated to the internal "_id" field.
+
+    A field whose name merely starts with the ID field (e.g. "id_code" when
+    the ID field is "id") must be left untouched.
+    """
+
+    class ItemDto(BaseModel):
+        id: int
+        id_code: int
+
+    ItemDtoDao = new_mock_dao_class(dto_model=ItemDto, id_field="id")  # noqa: N806
+    dao = ItemDtoDao()
+
+    dtos = [
+        ItemDto(id=1, id_code=30),
+        ItemDto(id=2, id_code=10),
+        ItemDto(id=3, id_code=20),
+    ]
+    for dto in dtos:
+        await dao.insert(dto)
+
+    # Sorting by the exact ID field maps to the internal "_id" field
+    assert [x.id async for x in dao.find_all(mapping={}, sort=["id"])] == [1, 2, 3]
+    assert [x.id async for x in dao.find_all(mapping={}, sort=["-id"])] == [3, 2, 1]
+
+    # Sorting by the prefix-colliding field sorts by *that* field, not the ID field
+    assert [x.id async for x in dao.find_all(mapping={}, sort=["id_code"])] == [2, 3, 1]
+
+
+async def test_sort_with_missing_values_matches_mongodb():
+    """Test that missing values are sorted consistently, matching MongoDB.
+
+    Missing/None values are grouped together and sorted ahead of present values in
+    ascending order (and after them in descending order), matching MongoDB. This also
+    exercises comparisons between None and present values, which would raise a TypeError
+    without the None-safe sort key.
+    """
+
+    class InnerDto(BaseModel):
+        x: int
+
+    class OuterDto(BaseModel):
+        id: int
+        inner: InnerDto | None = None
+
+    OuterDtoDao = new_mock_dao_class(dto_model=OuterDto, id_field="id")  # noqa: N806
+    dao = OuterDtoDao()
+
+    dtos = [
+        OuterDto(id=1, inner=InnerDto(x=3)),
+        OuterDto(id=2, inner=None),
+        OuterDto(id=3, inner=InnerDto(x=1)),
+        OuterDto(id=4, inner=None),
+    ]
+    for dto in dtos:
+        await dao.insert(dto)
+
+    # Ascending: missing (None) values first (insertion order kept among them), then
+    # present values in ascending order.
+    asc = [x.id async for x in dao.find_all(mapping={}, sort=["inner.x"])]
+    assert asc == [2, 4, 3, 1]
+
+    # Descending: present values in descending order, missing values last.
+    desc = [x.id async for x in dao.find_all(mapping={}, sort=["-inner.x"])]
+    assert desc == [1, 3, 2, 4]
+
+
+async def test_nested_id_sort_matches_mongodb():
+    """The in-mem DAO matches MongoDB's (limited) behavior: it cannot sort by a nested
+    sub-field of the ID field, because the ID is stored under "_id". Such a sort is a
+    no-op that preserves the existing order rather than raising or secretly resolving
+    the value - exactly as MongoDB would silently fail to sort by "inner.x".
+    """
+
+    class InnerDto(BaseModel):
+        def __hash__(self) -> int:
+            return self.x
+
+        x: int
+
+    class OuterDto(BaseModel):
+        inner: InnerDto
+        label: int
+
+    OuterDtoDao = new_mock_dao_class(dto_model=OuterDto, id_field="inner")  # noqa: N806
+    dao = OuterDtoDao()
+
+    dtos = [
+        OuterDto(inner=InnerDto(x=3), label=1),
+        OuterDto(inner=InnerDto(x=1), label=2),
+        OuterDto(inner=InnerDto(x=7), label=3),
+    ]
+    for dto in dtos:
+        await dao.insert(dto)
+
+    # Sorting by a nested sub-field of the ID field is a no-op (insertion order kept)
+    assert [x.label async for x in dao.find_all(mapping={}, sort=["inner.x"])] == [
+        1,
+        2,
+        3,
+    ]


### PR DESCRIPTION
Previously the InMemDao did a straight lookup by field name for sorting, which broke for nested fields. This fixes that.