### PR TITLE
Implement to_list() for DAOs (GSI-2465)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.3.1"
+version = "8.4.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.3.1"
+version = "8.4.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -171,7 +171,11 @@ class FindResult(AsyncIterator[Dto]):
         return self._cached_total
 
     async def to_list(self) -> list[Dto]:
-        """Collect all results into a list."""
+        """Collect all results into a list.
+
+        Calling this function will consume the iterator. Subsequent cals will return
+        an empty list.
+        """
         return [item async for item in self]
 
 

--- a/src/hexkit/protocols/dao.py
+++ b/src/hexkit/protocols/dao.py
@@ -170,6 +170,10 @@ class FindResult(AsyncIterator[Dto]):
             self._cached_total = await self._get_total_count()
         return self._cached_total
 
+    async def to_list(self) -> list[Dto]:
+        """Collect all results into a list."""
+        return [item async for item in self]
+
 
 class Dao(typing.Protocol[Dto]):
     """A duck type with methods common to all DAOs."""

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -801,6 +801,33 @@ async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
     assert over_skip == []
 
 
+async def test_dao_find_all_pagination_total_count(mongodb: MongoDbFixture):
+    """Test that a paginated find_all() returns only the paginated slice via to_list()
+    while total_count() reflects the full number of documents matching the filter.
+    """
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    # Five documents match the filter (field_c=True), two others should be excluded.
+    c_true_docs = [ExampleDto(field_b=b, field_c=True) for b in range(5)]
+    for doc in c_true_docs:
+        await dao.insert(doc)
+    for field_b in (100, 101):
+        await dao.insert(ExampleDto(field_b=field_b, field_c=False))
+
+    result = dao.find_all(mapping={"field_c": True}, skip=1, limit=3, sort=["field_b"])
+
+    # to_list() returns only the paginated slice: field_b in [1, 2, 3]
+    page = await result.to_list()
+    assert page == c_true_docs[1:4]
+
+    # total_count() reflects all documents matching the filter, ignoring skip/limit
+    assert await result.total_count() == 5
+
+
 async def test_dao_find_all_limit_zero(mongodb: MongoDbFixture):
     """Test that limit=0 returns an empty iterator but total_count still works."""
     dao = await mongodb.dao_factory.get_dao(

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -978,6 +978,10 @@ async def test_dao_find_all_to_list(mongodb: MongoDbFixture):
         id_field="id",
     )
 
+    # Verify that calling to_list() on an empty collection returns an empty list
+    assert await dao.find_all(mapping={}).to_list() == []
+
+    # Insert 3 docs
     resources = [ExampleDto(field_b=i) for i in range(3)]
     for resource in resources:
         await dao.insert(resource)

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -137,26 +137,23 @@ async def test_dao_find_all_with_id(mongodb: MongoDbFixture):
     await dao.insert(resource)
 
     # retrieve the resource with find_all
-    resources_read = [x async for x in dao.find_all(mapping={"id": resource.id})]
+    resources_read = await dao.find_all(mapping={"id": resource.id}).to_list()
     assert len(resources_read) == 1
     assert resources_read[0].id == resource.id
 
     # make sure the previous check wasn't a false positive
-    no_results = [x async for x in dao.find_all(mapping={"id": "noresults"})]
+    no_results = await dao.find_all(mapping={"id": "noresults"}).to_list()
     assert len(no_results) == 0
 
     # make sure other fields beside ID aren't getting ignored
-    no_results_multifield = [
-        x async for x in dao.find_all(mapping={"id": resource.id, "field_b": 134293487})
-    ]
+    no_results_multifield = await dao.find_all(
+        mapping={"id": resource.id, "field_b": 134293487}
+    ).to_list()
     assert len(no_results_multifield) == 0
 
-    multifield_found = [
-        x
-        async for x in dao.find_all(
-            mapping={"id": resource.id, "field_b": resource.field_b}
-        )
-    ]
+    multifield_found = await dao.find_all(
+        mapping={"id": resource.id, "field_b": resource.field_b}
+    ).to_list()
     assert len(multifield_found) == 1
     assert multifield_found[0] == resource
 
@@ -177,7 +174,7 @@ async def test_dao_find_all_without_collection(mongodb: MongoDbFixture):
     assert found is not None
 
     # retrieve the resource with find_all
-    resources_read = [x async for x in found]
+    resources_read = await found.to_list()
     assert len(resources_read) == 0
 
 
@@ -324,7 +321,7 @@ async def test_dao_find_invalid_mapping(mongodb: MongoDbFixture):
         await dao.find_one(mapping=mapping)
 
     with pytest.raises(InvalidFindMappingError):
-        [hit async for hit in dao.find_all(mapping=mapping)]
+        _ = dao.find_all(mapping=mapping)
 
 
 async def test_dao_find_no_hits(mongodb: MongoDbFixture):
@@ -339,7 +336,7 @@ async def test_dao_find_no_hits(mongodb: MongoDbFixture):
     with pytest.raises(NoHitsFoundError):
         await dao.find_one(mapping=mapping)
 
-    resources = [hit async for hit in dao.find_all(mapping=mapping)]
+    resources = await dao.find_all(mapping=mapping).to_list()
     assert len(resources) == 0
 
 
@@ -422,12 +419,12 @@ async def test_complex_models(mongodb: MongoDbFixture):
         for mapping in mappings:
             obtained_hit = await dao.find_one(mapping=mapping)
             assert obtained_hit == resource
-            obtained_hits = [hit async for hit in dao.find_all(mapping=mapping)]
+            obtained_hits = await dao.find_all(mapping=mapping).to_list()
             assert obtained_hits == [resource]
 
     for i in range(3):
         await dao.delete(resources[i].id)
-        obtained_hits = [hit async for hit in dao.find_all(mapping={})]
+        obtained_hits = await dao.find_all(mapping={}).to_list()
         assert len(obtained_hits) == 2 - i
 
 
@@ -800,7 +797,7 @@ async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
     assert paginated == [1, 2]
 
     # skip larger than collection size returns nothing
-    over_skip = [hit async for hit in dao.find_all(mapping={}, skip=10, sort=asc)]
+    over_skip = await dao.find_all(mapping={}, skip=10, sort=asc).to_list()
     assert over_skip == []
 
 
@@ -816,7 +813,7 @@ async def test_dao_find_all_limit_zero(mongodb: MongoDbFixture):
         await dao.insert(ExampleDto())
 
     result = dao.find_all(mapping={}, limit=0)
-    page = [hit async for hit in result]
+    page = await result.to_list()
     assert page == []
     assert await result.total_count() == 3
 
@@ -829,8 +826,7 @@ async def test_dao_find_all_pagination_empty_collection(mongodb: MongoDbFixture)
         id_field="id",
     )
 
-    results = [hit async for hit in dao.find_all(mapping={}, skip=5, limit=10)]
-    assert results == []
+    assert await dao.find_all(mapping={}, skip=5, limit=10).to_list() == []
 
 
 async def test_dao_find_all_pagination_negative_values(mongodb: MongoDbFixture):
@@ -842,10 +838,10 @@ async def test_dao_find_all_pagination_negative_values(mongodb: MongoDbFixture):
     )
 
     with pytest.raises(ValueError):
-        [hit async for hit in dao.find_all(mapping={}, skip=-1)]
+        _ = dao.find_all(mapping={}, skip=-1)
 
     with pytest.raises(ValueError):
-        [hit async for hit in dao.find_all(mapping={}, limit=-1)]
+        _ = dao.find_all(mapping={}, limit=-1)
 
 
 async def test_dao_find_all_sort_by_id_field(mongodb: MongoDbFixture):
@@ -927,7 +923,7 @@ async def test_dao_find_all_total_count_before_iteration(mongodb: MongoDbFixture
     total = await result.total_count()
     assert total == 3
 
-    page = [hit async for hit in result]
+    page = await result.to_list()
     assert len(page) == 1
 
 
@@ -943,7 +939,7 @@ async def test_dao_find_all_total_count_empty_filter_result(mongodb: MongoDbFixt
     await dao.insert(ExampleDto())
 
     result = dao.find_all(mapping={"field_b": 99999})
-    page = [hit async for hit in result]
+    page = await result.to_list()
     assert page == []
 
     total = await result.total_count()

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -783,49 +783,19 @@ async def test_dao_find_all_pagination(mongodb: MongoDbFixture):
     asc = ["field_b"]
 
     # skip=2 returns items with field_b in [2, 3, 4]
-    skipped = [hit.field_b async for hit in dao.find_all(mapping={}, skip=2, sort=asc)]
-    assert skipped == [2, 3, 4]
+    skipped = await dao.find_all(mapping={}, skip=2, sort=asc).to_list()
+    assert skipped == resources[2:]
 
     # limit=3 returns items with field_b in [0, 1, 2]
-    limited = [hit.field_b async for hit in dao.find_all(mapping={}, limit=3, sort=asc)]
-    assert limited == [0, 1, 2]
+    limited = await dao.find_all(mapping={}, limit=3, sort=asc).to_list()
+    assert limited == resources[:3]
 
     # skip=1, limit=2 returns items with field_b in [1, 2]
-    paginated = [
-        hit.field_b async for hit in dao.find_all(mapping={}, skip=1, limit=2, sort=asc)
-    ]
-    assert paginated == [1, 2]
+    paginated = await dao.find_all(mapping={}, skip=1, limit=2, sort=asc).to_list()
+    assert paginated == resources[1:3]
 
     # skip larger than collection size returns nothing
-    over_skip = await dao.find_all(mapping={}, skip=10, sort=asc).to_list()
-    assert over_skip == []
-
-
-async def test_dao_find_all_pagination_total_count(mongodb: MongoDbFixture):
-    """Test that a paginated find_all() returns only the paginated slice via to_list()
-    while total_count() reflects the full number of documents matching the filter.
-    """
-    dao = await mongodb.dao_factory.get_dao(
-        name="example",
-        dto_model=ExampleDto,
-        id_field="id",
-    )
-
-    # Five documents match the filter (field_c=True), two others should be excluded.
-    c_true_docs = [ExampleDto(field_b=b, field_c=True) for b in range(5)]
-    for doc in c_true_docs:
-        await dao.insert(doc)
-    for field_b in (100, 101):
-        await dao.insert(ExampleDto(field_b=field_b, field_c=False))
-
-    result = dao.find_all(mapping={"field_c": True}, skip=1, limit=3, sort=["field_b"])
-
-    # to_list() returns only the paginated slice: field_b in [1, 2, 3]
-    page = await result.to_list()
-    assert page == c_true_docs[1:4]
-
-    # total_count() reflects all documents matching the filter, ignoring skip/limit
-    assert await result.total_count() == 5
+    assert await dao.find_all(mapping={}, skip=10, sort=asc).to_list() == []
 
 
 async def test_dao_find_all_limit_zero(mongodb: MongoDbFixture):

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -972,3 +972,20 @@ async def test_dao_find_all_total_count(mongodb: MongoDbFixture):
     # calling total_count() a second time uses the cached value
     total_again = await result.total_count()
     assert total_again == 5
+
+
+async def test_dao_find_all_to_list(mongodb: MongoDbFixture):
+    """Test that to_list() collects all results into a list."""
+    dao = await mongodb.dao_factory.get_dao(
+        name="example",
+        dto_model=ExampleDto,
+        id_field="id",
+    )
+
+    resources = [ExampleDto(field_b=i) for i in range(3)]
+    for resource in resources:
+        await dao.insert(resource)
+
+    result = dao.find_all(mapping={}, sort=["field_b"])
+    items = await result.to_list()
+    assert [item.field_b for item in items] == [0, 1, 2]

--- a/tests/integration/providers/dao/test_mongodb_dao.py
+++ b/tests/integration/providers/dao/test_mongodb_dao.py
@@ -988,4 +988,9 @@ async def test_dao_find_all_to_list(mongodb: MongoDbFixture):
 
     result = dao.find_all(mapping={}, sort=["field_b"])
     items = await result.to_list()
-    assert [item.field_b for item in items] == [0, 1, 2]
+    assert isinstance(items, list)
+    assert items == resources
+    assert await result.total_count() == 3
+
+    # Check that calling to_list() again returns an empty list
+    assert await result.to_list() == []

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -1115,9 +1115,9 @@ async def test_pagination_against_metadataless_docs(mongo_kafka: MongoKafkaFixtu
         assert await result.total_count() == 5
 
         # Pagination still applies across all five live docs.
-        page = [x async for x in dao.find_all(mapping={}, limit=4)]
+        page = await dao.find_all(mapping={}, limit=4).to_list()
         assert len(page) == 4
-        remaining = [x async for x in dao.find_all(mapping={}, skip=4)]
+        remaining = await dao.find_all(mapping={}, skip=4).to_list()
         assert len(remaining) == 1
 
 
@@ -1134,10 +1134,15 @@ async def test_find_all_to_list(mongo_kafka: MongoKafkaFixture):
             event_topic=EXAMPLE_TOPIC,
         )
 
+        # Test on empty list
+        assert await dao.find_all(mapping={}).to_list() == []
+
+        # Insert 3 docs
         dtos = [ExampleDto(field_b=i) for i in range(3)]
         for dto in dtos:
             await dao.insert(dto)
 
+        # Verify that to_list does what it should
         result = dao.find_all(mapping={}, sort=["field_b"])
         items = await result.to_list()
         assert isinstance(items, list)

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -1120,3 +1120,27 @@ async def test_pagination_against_metadataless_docs(mongo_kafka: MongoKafkaFixtu
         assert len(page) == 4
         remaining = [x async for x in dao.find_all(mapping={}, skip=4)]
         assert len(remaining) == 1
+
+
+async def test_find_all_to_list(mongo_kafka: MongoKafkaFixture):
+    """Test that to_list() collects all results into a list."""
+    async with MongoKafkaDaoPublisherFactory.construct(
+        config=mongo_kafka.config
+    ) as factory:
+        dao = await factory.get_dao(
+            name="example",
+            dto_model=ExampleDto,
+            id_field="id",
+            dto_to_event=lambda dto: dto.model_dump(),
+            event_topic=EXAMPLE_TOPIC,
+        )
+
+        dtos = [ExampleDto(field_b=i) for i in range(3)]
+        for dto in dtos:
+            await dao.insert(dto)
+
+        result = dao.find_all(mapping={}, sort=["field_b"])
+        items = await result.to_list()
+        assert isinstance(items, list)
+        assert items == dtos
+        assert await result.total_count() == 3

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -316,7 +316,7 @@ async def test_dao_outbox_happy(dto_model: type, mongo_kafka: MongoKafkaFixture)
             await dao.get_by_id(example_id)
 
         # make sure that only 3 resources are left:
-        obtained_hits = {hit async for hit in dao.find_all(mapping={})}
+        obtained_hits = await dao.find_all(mapping={}).to_list()
         assert len(obtained_hits) == 3
 
 
@@ -400,13 +400,13 @@ async def test_complex_models(mongo_kafka: MongoKafkaFixture):
             for mapping in mappings:
                 obtained_hit = await dao.find_one(mapping=mapping)
                 assert obtained_hit == resource
-                obtained_hits = [hit async for hit in dao.find_all(mapping=mapping)]
+                obtained_hits = await dao.find_all(mapping=mapping).to_list()
                 assert obtained_hits == [resource]
 
         # stage 4: delete
         for i in range(3):
             await dao.delete(resources[i].id)
-            obtained_hits = [hit async for hit in dao.find_all(mapping={})]
+            obtained_hits = await dao.find_all(mapping={}).to_list()
             assert len(obtained_hits) == 2 - i
 
     # check that the expected events have been created
@@ -508,7 +508,7 @@ async def test_suppress_publishing(mongo_kafka: MongoKafkaFixture):
                 await dao.insert(example)
 
         # check that all resources were saved:
-        records = [record async for record in dao.find_all(mapping={})]
+        records = await dao.find_all(mapping={}).to_list()
         assert len(records) == 3
         assert any(record.field_c for record in records)
 
@@ -1033,11 +1033,10 @@ async def test_find_all_total_count_excludes_soft_deleted(
 
         # Run a query and make sure total_count() is 2
         result = dao.find_all(mapping={})
-        page = [hit async for hit in result]
+        page = await result.to_list()
         assert len(page) == 2
 
-        total = await result.total_count()
-        assert total == 2
+        assert await result.total_count() == 2
 
 
 async def test_pagination_against_deleted_docs(mongo_kafka: MongoKafkaFixture):

--- a/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
+++ b/tests/integration/providers/daopubsub/test_mongokafka_pubsub.py
@@ -316,7 +316,7 @@ async def test_dao_outbox_happy(dto_model: type, mongo_kafka: MongoKafkaFixture)
             await dao.get_by_id(example_id)
 
         # make sure that only 3 resources are left:
-        obtained_hits = await dao.find_all(mapping={}).to_list()
+        obtained_hits = {hit async for hit in dao.find_all(mapping={})}
         assert len(obtained_hits) == 3
 
 
@@ -1119,6 +1119,40 @@ async def test_pagination_against_metadataless_docs(mongo_kafka: MongoKafkaFixtu
         assert len(page) == 4
         remaining = await dao.find_all(mapping={}, skip=4).to_list()
         assert len(remaining) == 1
+
+
+async def test_find_all_pagination_total_count(mongo_kafka: MongoKafkaFixture):
+    """Test that a paginated find_all() returns only the paginated slice via to_list()
+    while total_count() reflects the full number of documents matching the filter.
+    """
+    async with MongoKafkaDaoPublisherFactory.construct(
+        config=mongo_kafka.config
+    ) as factory:
+        dao = await factory.get_dao(
+            name="example",
+            dto_model=ExampleDto,
+            id_field="id",
+            dto_to_event=lambda dto: dto.model_dump(),
+            event_topic=EXAMPLE_TOPIC,
+        )
+
+        # Five documents match the filter (field_c=True), two others should be excluded.
+        c_true_docs = [ExampleDto(field_b=b, field_c=True) for b in range(5)]
+        for doc in c_true_docs:
+            await dao.insert(doc)
+        for field_b in (100, 101):
+            await dao.insert(ExampleDto(field_b=field_b, field_c=False))
+
+        result = dao.find_all(
+            mapping={"field_c": True}, skip=1, limit=3, sort=["field_b"]
+        )
+
+        # to_list() returns only the paginated slice: field_b in [1, 2, 3]
+        page = await result.to_list()
+        assert page == c_true_docs[1:4]
+
+        # total_count() reflects all documents matching the filter, ignoring skip/limit
+        assert await result.total_count() == 5
 
 
 async def test_find_all_to_list(mongo_kafka: MongoKafkaFixture):

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -676,12 +676,14 @@ async def test_find_all_to_list():
     """Test that to_list() collects all results into a list."""
     dao = DaoClass()
     titles = ["Apple", "Banana", "Cherry"]
-    for title in titles:
-        await dao.insert(InventoryItem(title=title, count=1))
+    inserted = [InventoryItem(title=title, count=1) for title in titles]
+    for item in inserted:
+        await dao.insert(item)
 
     result = dao.find_all(mapping={}, sort=["title"])
     items = await result.to_list()
-    assert [item.title for item in items] == ["Apple", "Banana", "Cherry"]
+    assert isinstance(items, list)
+    assert items == inserted
 
 
 async def test_nested_sort_in_find_all():

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -673,6 +673,18 @@ async def test_find_all_total_count():
     assert total_again == 5
 
 
+async def test_find_all_to_list():
+    """Test that to_list() collects all results into a list."""
+    dao = DaoClass()
+    titles = ["Apple", "Banana", "Cherry"]
+    for title in titles:
+        await dao.insert(InventoryItem(title=title, count=1))
+
+    result = dao.find_all(mapping={}, sort=["title"])
+    items = await result.to_list()
+    assert [item.title for item in items] == ["Apple", "Banana", "Cherry"]
+
+
 async def test_nested_sort_in_find_all():
     """Test that `sort` works correctly in find_all() when the field is nested."""
 

--- a/tests/unit/test_in_mem_dao.py
+++ b/tests/unit/test_in_mem_dao.py
@@ -559,8 +559,7 @@ async def test_find_all_limit_zero_and_none():
 async def test_find_all_pagination_empty_collection():
     """Test find_all() with skip and limit on an empty collection produces no errors."""
     dao = DaoClass()
-    results = [x async for x in dao.find_all(mapping={}, skip=5, limit=10)]
-    assert results == []
+    assert await dao.find_all(mapping={}, skip=5, limit=10).to_list() == []
 
 
 async def test_find_all_pagination_negative_values():
@@ -568,13 +567,13 @@ async def test_find_all_pagination_negative_values():
     dao = DaoClass()
 
     with pytest.raises(ValueError):
-        [x async for x in dao.find_all(mapping={}, skip=-1)]
+        _ = dao.find_all(mapping={}, skip=-1)
 
     with pytest.raises(ValueError):
-        [x async for x in dao.find_all(mapping={}, limit=-1)]
+        _ = dao.find_all(mapping={}, limit=-1)
 
     with pytest.raises(ValueError):
-        [x async for x in dao.find_all(mapping={}, skip=-1, limit=-1)]
+        _ = dao.find_all(mapping={}, skip=-1, limit=-1)
 
 
 async def test_find_all_sort_by_id_field():
@@ -636,7 +635,7 @@ async def test_find_all_total_count_before_iteration():
     total = await result.total_count()
     assert total == 3
 
-    page = [x async for x in result]
+    page = await result.to_list()
     assert len(page) == 1
 
 
@@ -647,7 +646,7 @@ async def test_find_all_total_count_empty_filter_result():
     await dao.insert(InventoryItem(title="Banana", count=1))
 
     result = dao.find_all(mapping={"count": 999})
-    page = [x async for x in result]
+    page = await result.to_list()
     assert page == []
 
     total = await result.total_count()


### PR DESCRIPTION
This PR implements `.to_list()` for the `FindResult` class.

No version bump included because unreleased changes that are already merged to main have the requisite version bump.