### PR TITLE
Add `default=` keyword to config definitions (GSI-2461)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.4.0"
+version = "8.4.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.4.0"
+version = "8.4.1"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/log.py
+++ b/src/hexkit/log.py
@@ -49,12 +49,12 @@ class LoggingConfig(BaseSettings):
         default="INFO", description="The minimum log level to capture."
     )
     service_name: str = Field(
-        ...,
+        default=...,
         examples=["my-cool-special-service"],
         description="The name of the (micro-)service. This will be included in log messages.",
     )
     service_instance_id: str = Field(
-        ...,
+        default=...,
         examples=["germany-bw-instance-001"],
         description=(
             "A string that uniquely identifies this instance across all instances of"

--- a/src/hexkit/providers/mongodb/config.py
+++ b/src/hexkit/providers/mongodb/config.py
@@ -29,7 +29,7 @@ class MongoDbConfig(BaseSettings):
     """
 
     mongo_dsn: Secret[MongoDsn] = Field(
-        ...,
+        default=...,
         examples=["mongodb://localhost:27017"],
         description=(
             "MongoDB connection string. Might include credentials."
@@ -38,7 +38,7 @@ class MongoDbConfig(BaseSettings):
         ),
     )
     db_name: str = Field(
-        ...,
+        default=...,
         examples=["my-database"],
         description="Name of the database located on the MongoDB server.",
     )

--- a/src/hexkit/providers/redis/config.py
+++ b/src/hexkit/providers/redis/config.py
@@ -28,7 +28,7 @@ class RedisConfig(BaseSettings):
     """
 
     redis_url: Secret[RedisDsn] = Field(
-        ...,
+        default=...,
         examples=["redis://localhost:6379/0", "redis://:password@localhost:6379/1"],
         description=(
             "Redis connection URL. Might include credentials and database selection."

--- a/src/hexkit/providers/s3/config.py
+++ b/src/hexkit/providers/s3/config.py
@@ -31,10 +31,12 @@ class S3Config(BaseSettings):
     """
 
     s3_endpoint_url: str = Field(
-        ..., examples=["http://localhost:4566"], description="URL to the S3 API."
+        default=...,
+        examples=["http://localhost:4566"],
+        description="URL to the S3 API.",
     )
     s3_access_key_id: str = Field(
-        ...,
+        default=...,
         examples=["my-access-key-id"],
         description=(
             "Part of credentials for login into the S3 service. See:"
@@ -42,7 +44,7 @@ class S3Config(BaseSettings):
         ),
     )
     s3_secret_access_key: SecretStr = Field(
-        ...,
+        default=...,
         examples=["my-secret-access-key"],
         description=(
             "Part of credentials for login into the S3 service. See:"
@@ -50,7 +52,7 @@ class S3Config(BaseSettings):
         ),
     )
     s3_session_token: SecretStr | None = Field(
-        None,
+        default=None,
         examples=["my-session-token"],
         description=(
             "Part of credentials for login into the S3 service. See:"
@@ -58,7 +60,7 @@ class S3Config(BaseSettings):
         ),
     )
     aws_config_ini: Path | None = Field(
-        None,
+        default=None,
         examples=["~/.aws/config"],
         description=(
             "Path to a config file for specifying more advanced S3 parameters."

--- a/src/hexkit/providers/s3/testutils/_fixtures.py
+++ b/src/hexkit/providers/s3/testutils/_fixtures.py
@@ -241,7 +241,7 @@ class S3ContainerFixture(LocalStackContainer):
         # since IPVv6 can sometimes use a different port mapping,
         # which can shadow the IPv4 port mapping of a different container.
         url = url.replace("localhost", "127.0.0.1")
-        s3_config = S3Config(  # type: ignore [call-arg]
+        s3_config = S3Config(
             s3_endpoint_url=url,
             s3_access_key_id="test",
             s3_secret_access_key=SecretStr("test"),

--- a/src/hexkit/providers/vault/config.py
+++ b/src/hexkit/providers/vault/config.py
@@ -31,12 +31,12 @@ class VaultConfig(BaseSettings):
     """
 
     vault_url: str = Field(
-        ...,
+        default=...,
         examples=["http://localhost:8200", "https://vault.example.com:8200"],
         description="URL of the Vault server.",
     )
     vault_path: str = Field(
-        ...,
+        default=...,
         examples=["myapp/secrets", "production/config"],
         description=(
             "Path prefix for all keys stored in Vault."


### PR DESCRIPTION
Bumps version to 8.4.1. This should get rid of constant mypy errors complaining about `config = Config()`.