### PR TITLE
Move pagination into asyncio.to_thread

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.4.1"
+version = "8.4.2"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.4.1"
+version = "8.4.2"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -344,8 +344,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
     ) -> list[str]:
         """Lists all active multipart uploads for the given object ID.
 
-        Uses a filter (Prefix=object_id) to narrow the selection server side, which
-        currently holds for hexkit. If this ever changes, the filter needs to be removed.
+        Uses a filter (Prefix=object_id) to narrow the selection server side. Only works
+        as long as Key=object_id. If this ever changes, the filter needs to be removed.
 
         Raises a `BucketNotFoundError` if the bucket does not exist.
 

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -344,31 +344,34 @@ class S3ObjectStorage(ObjectStorageProtocol):
     ) -> list[str]:
         """Lists all active multipart uploads for the given object ID.
 
+        Uses a filter (Prefix=object_id) to narrow the selection server side, which
+        currently holds for hexkit. If this ever changes, the filter needs to be removed.
+
         Raises a `BucketNotFoundError` if the bucket does not exist.
 
         Boto3 Documentation:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/list_multipart_uploads.html#S3.Client.list_multipart_uploads
         """
-        uploads: list[str] = []
-        try:
-            response_iter = await asyncio.to_thread(
-                self._client.get_paginator("list_multipart_uploads").paginate,
-                Bucket=bucket_id,
-            )
-            for response_page in response_iter:
+
+        def _list_uploads() -> list[str]:
+            """Factored out, so .paginate is called inside asyncio.to_thread."""
+            paginator = self._client.get_paginator("list_multipart_uploads")
+            uploads: list[str] = []
+            # prefix filtering only works as long as Key=object_id
+            for response_page in paginator.paginate(Bucket=bucket_id, Prefix=object_id):
                 uploads.extend(
-                    [
-                        upload["UploadId"]
-                        for upload in response_page.get("Uploads", [])
-                        if upload["Key"] == object_id
-                    ]
+                    upload["UploadId"]
+                    for upload in response_page.get("Uploads", [])
+                    if upload["Key"] == object_id
                 )
+            return uploads
+
+        try:
+            return await asyncio.to_thread(_list_uploads)
         except botocore.exceptions.ClientError as error:
             raise self._translate_s3_client_errors(
                 error, bucket_id=bucket_id, object_id=object_id
             ) from error
-
-        return uploads
 
     async def _list_parts(
         self,
@@ -420,18 +423,20 @@ class S3ObjectStorage(ObjectStorageProtocol):
                     f"{first_part_no} is not a valid argument for first_part_no"
                 )
 
-        try:
+        def _list_parts() -> list[dict]:
+            """Factored out, so .paginate is called inside asyncio.to_thread."""
+            paginator = self._client.get_paginator("list_parts")
             parts: list[dict] = []
-            response_iter = await asyncio.to_thread(
-                self._client.get_paginator("list_parts").paginate, **params
-            )
-            for page in response_iter:
+            for page in paginator.paginate(**params):
                 parts.extend(page.get("Parts", []))
 
                 # If max_parts specified, return once amount is reached
                 if max_parts and len(parts) >= max_parts:
                     return parts[: max_parts + 1]
             return sorted(parts, key=lambda p: p["PartNumber"])
+
+        try:
+            return await asyncio.to_thread(_list_parts)
         except botocore.exceptions.ClientError as error:
             raise self._translate_s3_client_errors(
                 error,
@@ -449,25 +454,26 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
         Raises a `BucketNotFoundError` if the bucket does not exist.
         """
-        uploads: dict[str, str] = {}
-        try:
-            response_iter = await asyncio.to_thread(
-                self._client.get_paginator("list_multipart_uploads").paginate,
-                Bucket=bucket_id,
-            )
-            for response_page in response_iter:
+
+        def _list_all_uploads() -> dict[str, str]:
+            """Factored out, so .paginate is called inside asyncio.to_thread."""
+            paginator = self._client.get_paginator("list_multipart_uploads")
+            uploads: dict[str, str] = {}
+            for response_page in paginator.paginate(Bucket=bucket_id):
                 uploads.update(
                     {
                         upload["UploadId"]: upload["Key"]
                         for upload in response_page.get("Uploads", [])
                     }
                 )
+            return uploads
+
+        try:
+            return await asyncio.to_thread(_list_all_uploads)
         except botocore.exceptions.ClientError as error:
             raise self._translate_s3_client_errors(
                 error, bucket_id=bucket_id
             ) from error
-
-        return uploads
 
     async def _assert_no_multipart_upload(self, *, bucket_id: str, object_id: str):
         """Ensure that there are no active multi-part uploads for the given object."""

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -698,6 +698,46 @@ async def test_list_multipart_uploads_for_object(s3: S3Fixture):
     assert uploads == []
 
 
+async def test_prefix_filter_ignores_sibling_object_ids(s3: S3Fixture):
+    """Ensure server-side `Prefix` filtering does not conflate object IDs that share
+    a prefix.
+    """
+    bucket_id = "test"
+    await s3.storage.create_bucket(bucket_id)
+
+    # "abc" is a strict prefix of "abcd", so Prefix="abc" matches both server-side.
+    short_object_id = "abc"
+    long_object_id = "abcd"
+
+    short_upload_id = await s3.storage.init_multipart_upload(
+        bucket_id=bucket_id, object_id=short_object_id
+    )
+    long_upload_id = await s3.storage.init_multipart_upload(
+        bucket_id=bucket_id, object_id=long_object_id
+    )
+
+    # Filter matches both, but we extract by key on the filtered list
+    # These should return only for the correct object id
+    uploads = await s3.storage.list_multipart_uploads_for_object(
+        bucket_id=bucket_id, object_id=short_object_id
+    )
+    assert uploads == [short_upload_id]
+
+    uploads = await s3.storage.list_multipart_uploads_for_object(
+        bucket_id=bucket_id, object_id=long_object_id
+    )
+    assert uploads == [long_upload_id]
+
+    # Ensure this also doesn't raise MultipleActiveUploadsError.
+    url = await s3.storage.get_part_upload_url(
+        upload_id=short_upload_id,
+        bucket_id=bucket_id,
+        object_id=short_object_id,
+        part_number=1,
+    )
+    assert url
+
+
 async def test_get_all_multipart_uploads(s3: S3Fixture):
     """Test the get_all_multipart_uploads method."""
     bucket_id = "my-bucket"


### PR DESCRIPTION
Currently the pagination and related IO accidentally happen synchronously on the main thread.
This PR moves the corresponding callsites completely into `asyncio.to_thread` which should correctly dispatch them on separate threads.

As a performance optimization, `_list_multipart_uploads_for_object` now uses a `Prefix=object_id` filter. This works for the current setup, but will break if we ever change *any* functionality that creates an object to use anything else than `Key=object_id`.