### PR TITLE
Reduce S3 Calls (GSI-2490)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hexkit"
-version = "8.4.2"
+version = "8.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 requires-python = ">=3.10"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "hexkit"
-version = "8.4.2"
+version = "8.5.0"
 description = "A Toolkit for Building Microservices using the Hexagonal Architecture"
 dependencies = [
     "opentelemetry-api >=1.39, <2",

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -20,7 +20,7 @@
 
 import re
 from abc import ABC, abstractmethod
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 __all__ = ["ObjectStorageProtocol", "PresignedPostURL"]
 
@@ -278,6 +278,14 @@ class ObjectStorageProtocol(ABC):
         self._validate_object_id(object_id)
         return await self._get_object_size(bucket_id=bucket_id, object_id=object_id)
 
+    async def get_object_metadata(
+        self, *, bucket_id: str, object_id: str
+    ) -> dict[str, Any]:
+        """Returns object metadata without downloading the actual object."""
+        self._validate_bucket_id(bucket_id)
+        self._validate_object_id(object_id)
+        return await self._get_object_metadata(bucket_id=bucket_id, object_id=object_id)
+
     async def copy_object(
         self,
         *,
@@ -508,6 +516,7 @@ class ObjectStorageProtocol(ABC):
         *To be implemented by the provider. Input validation is done outside of this
         method.*
         """
+        ...
 
     @abstractmethod
     async def _get_object_download_url(
@@ -530,6 +539,7 @@ class ObjectStorageProtocol(ABC):
         *To be implemented by the provider. Input validation is done outside of this
         method.*
         """
+        ...
 
     @abstractmethod
     async def _get_object_size(self, *, bucket_id: str, object_id: str) -> int:
@@ -539,6 +549,13 @@ class ObjectStorageProtocol(ABC):
         *To be implemented by the provider. Input validation is done outside of this
         method.*
         """
+        ...
+
+    @abstractmethod
+    async def _get_object_metadata(
+        self, *, bucket_id: str, object_id: str
+    ) -> dict[str, Any]:
+        """Returns object metadata without downloading the actual object."""
         ...
 
     @abstractmethod

--- a/src/hexkit/protocols/objstorage.py
+++ b/src/hexkit/protocols/objstorage.py
@@ -318,6 +318,9 @@ class ObjectStorageProtocol(ABC):
     async def delete_object(self, *, bucket_id: str, object_id: str) -> None:
         """Delete an object with the specified id (`object_id`) in the bucket with the
         specified id (`bucket_id`).
+
+        Deleting an object that does not exist succeeds silently. However, a
+        `BucketNotFoundError` is raised if the bucket does not exist.
         """
         self._validate_bucket_id(bucket_id)
         self._validate_object_id(object_id)
@@ -601,6 +604,9 @@ class ObjectStorageProtocol(ABC):
     async def _delete_object(self, *, bucket_id: str, object_id: str) -> None:
         """Delete an object with the specified id (`object_id`) in the bucket with the
         specified id (`bucket_id`).
+
+        Deleting an object that does not exist succeeds silently. However, a
+        `BucketNotFoundError` is raised if the bucket does not exist.
 
         *To be implemented by the provider. Input validation is done outside of this
         method.*

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -549,8 +549,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 + f" smaller or equal to {self.MAX_FILE_PART_NUMBER}"
             )
 
-        # Upload check needed: presigning is local-only, so a missing upload or
-        # multiple active uploads can only be detected here.
+        # Upload check needed: presigning is local-only, so a missing upload can
+        # only be detected here. Exclusiveness is not enforced: upload_id is explicit.
         await self._assert_multipart_upload_exists(
             upload_id=upload_id,
             bucket_id=bucket_id,

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -859,14 +859,13 @@ class S3ObjectStorage(ObjectStorageProtocol):
         This only works reliably as long as there are no other ongoing multipart operations for
         the same destination bucket and object ID, in which case this should be set to false.
         """
-        file_size = await self._get_object_size(
-            bucket_id=source_bucket_id, object_id=source_object_id
-        )
-
-        # Destination object check needed: CopyObject silently overwrites; the size
-        # lookup above already validated the source.
+        # Before doing anything else, make sure the target doesn't already exist
         await self._assert_object_not_exists(
             bucket_id=dest_bucket_id, object_id=dest_object_id
+        )
+
+        file_size = await self._get_object_size(
+            bucket_id=source_bucket_id, object_id=source_object_id
         )
         part_size = calc_part_size(file_size=file_size)
 

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -824,11 +824,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
     async def _get_object_metadata(
         self, *, bucket_id: str, object_id: str
     ) -> dict[str, Any]:
-        """Returns object metadata without downloading the actual object.
-
-        No bucket/object checks needed: head_object fails itself; on its ambiguous
-        404, a bucket check picks BucketNotFoundError vs ObjectNotFoundError.
-        """
+        """Returns object metadata without downloading the actual object."""
         try:
             return await asyncio.to_thread(
                 self._client.head_object,

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -185,14 +185,6 @@ class S3ObjectStorage(ObjectStorageProtocol):
             ) from error
         return True
 
-    async def _assert_bucket_exists(self, bucket_id: str) -> None:
-        """Assert that the bucket with the specified ID (`bucket_id`) exists.
-
-        If it does not exist, a BucketNotFoundError is raised.
-        """
-        if not await self.does_bucket_exist(bucket_id):
-            raise self.BucketNotFoundError(bucket_id=bucket_id)
-
     async def _assert_bucket_not_exists(self, bucket_id: str) -> None:
         """Assert that the bucket with the specified ID (`bucket_id`) does not exist.
 
@@ -206,6 +198,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         Create a bucket (= a structure that can hold multiple file objects) with the
         specified unique ID.
         """
+        # Bucket check needed: S3 silently succeeds when re-creating a bucket you own.
         await self._assert_bucket_not_exists(bucket_id)
 
         try:
@@ -224,8 +217,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         will be deleted, if False (the default) a BucketNotEmptyError will be raised if
         the bucket is not empty.
         """
-        await self._assert_bucket_exists(bucket_id)
-
+        # No bucket check needed: deletion raises NoSuchBucket for a missing bucket.
         try:
             bucket = self._resource.Bucket(bucket_id)  # pyright: ignore
             content = await asyncio.to_thread(bucket.objects.all)
@@ -239,8 +231,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
     async def _list_all_object_ids(self, *, bucket_id: str) -> list[str]:
         """Retrieve a list of IDs for all objects currently present in the specified bucket"""
-        await self._assert_bucket_exists(bucket_id)
-
+        # No bucket check needed: listing raises NoSuchBucket for a missing bucket.
         try:
             bucket = self._resource.Bucket(bucket_id)  # pyright: ignore
             content = await asyncio.to_thread(bucket.objects.all)
@@ -277,11 +268,13 @@ class S3ObjectStorage(ObjectStorageProtocol):
         the specified ID (`bucket_id`) and throws an ObjectNotFoundError otherwise.
         If the bucket does not exist it throws a BucketNotFoundError.
         """
-        # first check if bucket exists:
-        await self._assert_bucket_exists(bucket_id)
-
-        if not await self.does_object_exist(bucket_id=bucket_id, object_id=object_id):
-            raise self.ObjectNotFoundError(bucket_id=bucket_id, object_id=object_id)
+        # head_object 404s can't tell a missing bucket from a missing object, so the
+        # bucket is only checked when the object check fails (common case: one call).
+        if await self.does_object_exist(bucket_id=bucket_id, object_id=object_id):
+            return
+        if not await self.does_bucket_exist(bucket_id):
+            raise self.BucketNotFoundError(bucket_id=bucket_id)
+        raise self.ObjectNotFoundError(bucket_id=bucket_id, object_id=object_id)
 
     async def _assert_object_not_exists(
         self, *, bucket_id: str, object_id: str
@@ -290,13 +283,13 @@ class S3ObjectStorage(ObjectStorageProtocol):
         the specified ID (`bucket_id`). If so, it throws an ObjectAlreadyExistsError.
         If the bucket does not exist it throws a BucketNotFoundError.
         """
-        # first check if bucket exists:
-        await self._assert_bucket_exists(bucket_id)
-
+        # See _assert_object_exists for why the object is checked before the bucket.
         if await self.does_object_exist(bucket_id=bucket_id, object_id=object_id):
             raise self.ObjectAlreadyExistsError(
                 bucket_id=bucket_id, object_id=object_id
             )
+        if not await self.does_bucket_exist(bucket_id):
+            raise self.BucketNotFoundError(bucket_id=bucket_id)
 
     async def _get_object_upload_url(
         self,
@@ -311,6 +304,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
         You may also specify a custom expiry duration in seconds (`expires_after`) and
         a maximum size (bytes) for uploads (`max_upload_size`).
         """
+        # Bucket/object checks needed: presigning is local-only and uploading via
+        # the URL would silently overwrite an existing object.
         await self._assert_object_not_exists(bucket_id=bucket_id, object_id=object_id)
 
         conditions = (
@@ -399,10 +394,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
             ValueError if `max_parts` or `first_part_no` are invalid.
             MultiPartUploadNotFoundError if no upload with `upload_id` exists.
         """
-        await self._assert_multipart_upload_exists(
-            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
-        )
-
+        # No upload check needed: ListParts raises NoSuchUpload/NoSuchBucket itself,
+        # and exclusiveness doesn't matter for one specific upload_id.
         params: dict[str, Any] = {
             "Bucket": bucket_id,
             "Key": object_id,
@@ -518,6 +511,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
     async def _init_multipart_upload(self, *, bucket_id: str, object_id: str) -> str:
         """Initiates a multipart upload procedure. Returns the upload ID."""
+        # Upload check needed: S3 allows multiple concurrent uploads per object, so
+        # exclusiveness can only be ensured upfront (also covers NoSuchBucket).
         await self._assert_no_multipart_upload(bucket_id=bucket_id, object_id=object_id)
 
         try:
@@ -554,6 +549,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 + f" smaller or equal to {self.MAX_FILE_PART_NUMBER}"
             )
 
+        # Upload check needed: presigning is local-only, so a missing upload or
+        # multiple active uploads can only be detected here.
         await self._assert_multipart_upload_exists(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
@@ -675,15 +672,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
         """Abort a multipart upload with the specified ID. All uploaded content is
         deleted.
         """
-        await self._assert_multipart_upload_exists(
-            upload_id=upload_id,
-            bucket_id=bucket_id,
-            object_id=object_id,
-            assert_exclusiveness=False,
-        )
-        # Exclusiveness is not enforced here since the abortion of an upload might be
-        # used to resolve the invalid state of multiple uploads for the same object.
-
+        # No upload check needed: abort raises NoSuchUpload/NoSuchBucket itself, and
+        # exclusiveness isn't enforced since aborting may resolve that very state.
         try:
             await asyncio.to_thread(
                 self._client.abort_multipart_upload,
@@ -779,6 +769,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
         the specified ID (`object_id`) from bucket with the specified id (`bucket_id`).
         You may also specify a custom expiry duration in seconds (`expires_after`).
         """
+        # Bucket/object checks needed: presigning is local-only, so a URL for a
+        # missing object would be handed out without error.
         await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
 
         try:
@@ -797,8 +789,6 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
     async def _get_object_etag(self, *, bucket_id: str, object_id: str) -> str:
         """Return the etag of an object."""
-        await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
-
         object_metadata = await self._get_object_metadata(
             bucket_id=bucket_id, object_id=object_id
         )
@@ -813,8 +803,6 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
     async def _get_object_size(self, *, bucket_id: str, object_id: str) -> int:
         """Returns the size of an object in bytes."""
-        await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
-
         object_metadata = await self._get_object_metadata(
             bucket_id=bucket_id, object_id=object_id
         )
@@ -830,17 +818,27 @@ class S3ObjectStorage(ObjectStorageProtocol):
     async def _get_object_metadata(
         self, *, bucket_id: str, object_id: str
     ) -> dict[str, Any]:
-        """Returns object metadata without downloading the actual object."""
+        """Returns object metadata without downloading the actual object.
+
+        No bucket/object checks needed: head_object fails itself; on its ambiguous
+        404, a bucket check picks BucketNotFoundError vs ObjectNotFoundError.
+        """
         try:
-            metadata = await asyncio.to_thread(
+            return await asyncio.to_thread(
                 self._client.head_object,
                 Bucket=bucket_id,
                 Key=object_id,
             )
         except botocore.exceptions.ClientError as error:
-            raise self._translate_s3_client_errors(error) from error
-
-        return metadata
+            if error.response["Error"]["Code"] == "404":
+                if not await self.does_bucket_exist(bucket_id):
+                    raise self.BucketNotFoundError(bucket_id=bucket_id) from error
+                raise self.ObjectNotFoundError(
+                    bucket_id=bucket_id, object_id=object_id
+                ) from error
+            raise self._translate_s3_client_errors(
+                error, bucket_id=bucket_id, object_id=object_id
+            ) from error
 
     async def _copy_object(
         self,
@@ -863,6 +861,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
             bucket_id=source_bucket_id, object_id=source_object_id
         )
 
+        # Destination object check needed: CopyObject silently overwrites; the size
+        # lookup above already validated the source.
         await self._assert_object_not_exists(
             bucket_id=dest_bucket_id, object_id=dest_object_id
         )
@@ -907,6 +907,7 @@ class S3ObjectStorage(ObjectStorageProtocol):
         """Delete an object with the specified id (`object_id`) in the bucket with the
         specified id (`bucket_id`).
         """
+        # Object check needed: DeleteObject reports success even for missing objects.
         await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
 
         try:

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -549,13 +549,10 @@ class S3ObjectStorage(ObjectStorageProtocol):
                 + f" smaller or equal to {self.MAX_FILE_PART_NUMBER}"
             )
 
-        # Upload check needed: presigning is local-only, so a missing upload can
-        # only be detected here. Exclusiveness is not enforced: upload_id is explicit.
+        # Upload check needed: presigning is local-only, so a missing upload or
+        # multiple active uploads can only be detected here.
         await self._assert_multipart_upload_exists(
-            upload_id=upload_id,
-            bucket_id=bucket_id,
-            object_id=object_id,
-            assert_exclusiveness=False,
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
 
         params = {
@@ -728,6 +725,12 @@ class S3ObjectStorage(ObjectStorageProtocol):
         This ensures that exactly the specified number of parts exist and that all parts
         (except the last one) have the specified size.
         """
+        # Upload check needed to keep raising MultipleActiveUploadsError for multiple
+        # active uploads; ListParts alone would only detect a missing upload.
+        await self._assert_multipart_upload_exists(
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+        )
+
         parts = await self._list_parts(
             upload_id=upload_id,
             bucket_id=bucket_id,

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -220,8 +220,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
         # No bucket check needed: deletion raises NoSuchBucket for a missing bucket.
         try:
             bucket = self._resource.Bucket(bucket_id)  # pyright: ignore
-            content = await asyncio.to_thread(bucket.objects.all)
             if delete_content:
+                content = await asyncio.to_thread(bucket.objects.all)
                 await asyncio.to_thread(content.delete)
             await asyncio.to_thread(bucket.delete)
         except botocore.exceptions.ClientError as error:

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -909,9 +909,6 @@ class S3ObjectStorage(ObjectStorageProtocol):
         """Delete an object with the specified id (`object_id`) in the bucket with the
         specified id (`bucket_id`).
         """
-        # Object check needed: DeleteObject reports success even for missing objects.
-        await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
-
         try:
             await asyncio.to_thread(
                 self._client.delete_object,

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -551,6 +551,8 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
         # Upload check needed: presigning is local-only, so a missing upload or
         # multiple active uploads can only be detected here.
+        # TODO: Since upload ID is included, we shouldn't check for multiple uploads
+        #  here - that should be done elsewhere. Set assert_exclusiveness to False
         await self._assert_multipart_upload_exists(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )

--- a/src/hexkit/providers/s3/provider/objstorage.py
+++ b/src/hexkit/providers/s3/provider/objstorage.py
@@ -551,10 +551,11 @@ class S3ObjectStorage(ObjectStorageProtocol):
 
         # Upload check needed: presigning is local-only, so a missing upload or
         # multiple active uploads can only be detected here.
-        # TODO: Since upload ID is included, we shouldn't check for multiple uploads
-        #  here - that should be done elsewhere. Set assert_exclusiveness to False
         await self._assert_multipart_upload_exists(
-            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+            upload_id=upload_id,
+            bucket_id=bucket_id,
+            object_id=object_id,
+            assert_exclusiveness=False,
         )
 
         params = {

--- a/src/hexkit/providers/testing/objstorage.py
+++ b/src/hexkit/providers/testing/objstorage.py
@@ -16,7 +16,6 @@
 """Mock object storage class"""
 
 from collections import defaultdict
-from contextlib import suppress
 from typing import Any
 from uuid import uuid4
 
@@ -287,12 +286,13 @@ class InMemObjectStorage(ObjectStorageProtocol):
         """Delete an object with the specified id (`object_id`) in the bucket with the
         specified id (`bucket_id`).
 
+        Deleting an object that does not exist succeeds silently.
+
         Raises:
             `BucketNotFoundError`: If the bucket does not exist.
-            `ObjectNotFoundError`: If the object does not exist in the bucket.
         """
-        with suppress(KeyError):
-            self.buckets[bucket_id].remove(object_id)
+        await self._assert_bucket_exists(bucket_id)
+        self.buckets[bucket_id].discard(object_id)
 
     async def _init_multipart_upload(self, *, bucket_id: str, object_id: str) -> str:
         """Initiates a multipart upload procedure. Returns the upload ID.
@@ -432,8 +432,14 @@ class InMemObjectStorage(ObjectStorageProtocol):
     async def _get_object_metadata(
         self, *, bucket_id: str, object_id: str
     ) -> dict[str, Any]:
+        """Returns object metadata with the same keys as an S3 `HeadObject` response.
+
+        Raises:
+            `BucketNotFoundError`: If the bucket does not exist.
+            `ObjectNotFoundError`: If the object does not exist in the bucket.
+        """
         await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
-        return {"Size": 1024, "Etag": f"etag_for_{object_id}"}
+        return {"ContentLength": 1024, "ETag": f"etag_for_{object_id}"}
 
     async def _copy_object(
         self,

--- a/src/hexkit/providers/testing/objstorage.py
+++ b/src/hexkit/providers/testing/objstorage.py
@@ -16,6 +16,8 @@
 """Mock object storage class"""
 
 from collections import defaultdict
+from contextlib import suppress
+from typing import Any
 from uuid import uuid4
 
 from hexkit.protocols.objstorage import ObjectStorageProtocol, PresignedPostURL
@@ -289,8 +291,8 @@ class InMemObjectStorage(ObjectStorageProtocol):
             `BucketNotFoundError`: If the bucket does not exist.
             `ObjectNotFoundError`: If the object does not exist in the bucket.
         """
-        await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
-        self.buckets[bucket_id].remove(object_id)
+        with suppress(KeyError):
+            self.buckets[bucket_id].remove(object_id)
 
     async def _init_multipart_upload(self, *, bucket_id: str, object_id: str) -> str:
         """Initiates a multipart upload procedure. Returns the upload ID.
@@ -426,6 +428,12 @@ class InMemObjectStorage(ObjectStorageProtocol):
         """
         await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
         return 1024
+
+    async def _get_object_metadata(
+        self, *, bucket_id: str, object_id: str
+    ) -> dict[str, Any]:
+        await self._assert_object_exists(bucket_id=bucket_id, object_id=object_id)
+        return {"Size": 1024, "Etag": f"etag_for_{object_id}"}
 
     async def _copy_object(
         self,

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -730,7 +730,7 @@ async def test_prefix_filter_ignores_sibling_object_ids(s3: S3Fixture):
     )
     assert uploads == [long_upload_id]
 
-    # Ensure this also doesn't raise MultipleActiveUploadsError.
+    # The upload check should still find the upload despite the prefix-sharing sibling.
     url = await s3.storage.get_part_upload_url(
         upload_id=short_upload_id,
         bucket_id=bucket_id,
@@ -819,8 +819,16 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
     Test that the invalid state of multiple uploads coexisting for the same object
     is correctly handled.
     """
-    # initialize an upload and upload its one part before any sibling exists:
+    # initialize an upload:
     upload1_id, bucket_id, object_id = await s3.get_initialized_upload()
+
+    # initialize another upload bypassing any checks:
+    upload2_id = s3.storage._client.create_multipart_upload(
+        Bucket=bucket_id, Key=object_id
+    )["UploadId"]
+
+    # uploading a part and completing the upload both target an explicit
+    # upload_id, so they keep working while a sibling upload is active:
     await upload_part(
         s3.storage,
         upload_id=upload1_id,
@@ -829,25 +837,6 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
         content=b"Test content.",
         part_number=1,
     )
-
-    # initialize another upload bypassing any checks:
-    upload2_id = s3.storage._client.create_multipart_upload(
-        Bucket=bucket_id, Key=object_id
-    )["UploadId"]
-
-    # get_part_upload_url refuses to hand out a URL while multiple uploads are
-    # active for the object, no matter which of the two upload_ids is targeted,
-    # since it has no other opportunity to surface the anomaly (URL signing itself
-    # never touches S3):
-    for upload_id in [upload1_id, upload2_id]:
-        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
-            await s3.storage.get_part_upload_url(
-                upload_id=upload_id,
-                bucket_id=bucket_id,
-                object_id=object_id,
-                part_number=2,
-            )
-
     await s3.storage.complete_multipart_upload(
         upload_id=upload1_id, bucket_id=bucket_id, object_id=object_id
     )

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -15,7 +15,7 @@
 
 """Test S3 storage DAO"""
 
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
@@ -322,9 +322,6 @@ async def test_using_non_existing_upload(
     bucket_id = real_bucket_id if bucket_id_correct else "wrong-bucket"
     object_id = real_object_id if object_id_correct else "wrong-object"
 
-    def get_exception_context() -> AbstractContextManager:
-        return pytest.raises(exception) if exception else nullcontext()
-
     # call relevant methods from the provider:
     with pytest.raises(exception):
         await s3.storage._assert_multipart_upload_exists(
@@ -338,6 +335,11 @@ async def test_using_non_existing_upload(
 
     with pytest.raises(exception):
         await s3.storage.complete_multipart_upload(
+            upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+        )
+
+    with pytest.raises(exception):
+        await s3.storage.abort_multipart_upload(
             upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
         )
 
@@ -817,35 +819,8 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
     Test that the invalid state of multiple uploads coexisting for the same object
     is correctly handled.
     """
-    # initialize an upload:
+    # initialize an upload and upload its one part before any sibling exists:
     upload1_id, bucket_id, object_id = await s3.get_initialized_upload()
-
-    # initialize another upload bypassing any checks:
-    upload2_id = s3.storage._client.create_multipart_upload(
-        Bucket=bucket_id, Key=object_id
-    )["UploadId"]
-
-    # try to work on both uploads:
-    for upload_id in [upload1_id, upload2_id]:
-        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
-            await s3.storage.get_part_upload_url(
-                upload_id=upload_id,
-                bucket_id=bucket_id,
-                object_id=object_id,
-                part_number=1,
-            )
-
-        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
-            await s3.storage.complete_multipart_upload(
-                upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
-            )
-
-    # aborting should work:
-    await s3.storage.abort_multipart_upload(
-        upload_id=upload2_id, bucket_id=bucket_id, object_id=object_id
-    )
-
-    # confirm that aborting one upload fixes the problem
     await upload_part(
         s3.storage,
         upload_id=upload1_id,
@@ -854,8 +829,32 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
         content=b"Test content.",
         part_number=1,
     )
+
+    # initialize another upload bypassing any checks:
+    upload2_id = s3.storage._client.create_multipart_upload(
+        Bucket=bucket_id, Key=object_id
+    )["UploadId"]
+
+    # get_part_upload_url refuses to hand out a URL while multiple uploads are
+    # active for the object, no matter which of the two upload_ids is targeted,
+    # since it has no other opportunity to surface the anomaly (URL signing itself
+    # never touches S3):
+    for upload_id in [upload1_id, upload2_id]:
+        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
+            await s3.storage.get_part_upload_url(
+                upload_id=upload_id,
+                bucket_id=bucket_id,
+                object_id=object_id,
+                part_number=2,
+            )
+
     await s3.storage.complete_multipart_upload(
         upload_id=upload1_id, bucket_id=bucket_id, object_id=object_id
+    )
+
+    # the other upload is left dangling and must be cleaned up explicitly
+    await s3.storage.abort_multipart_upload(
+        upload_id=upload2_id, bucket_id=bucket_id, object_id=object_id
     )
 
 

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -140,6 +140,17 @@ async def test_get_object_size(s3: S3Fixture, tmp_file: FileObject):  # noqa: F8
     assert expected_size == observed_size
 
 
+async def test_get_object_metadata(s3: S3Fixture, tmp_file: FileObject):  # noqa: F811
+    """Test if the get_object_metadata method returns the expected fields."""
+    await s3.populate_file_objects([tmp_file])
+    object_metadata = await s3.storage.get_object_metadata(
+        bucket_id=tmp_file.bucket_id, object_id=tmp_file.object_id
+    )
+
+    assert object_metadata["ContentLength"] == len(tmp_file.content)
+    assert object_metadata["ETag"]
+
+
 async def test_list_all_object_ids(s3: S3Fixture, tmp_file: FileObject):  # noqa: F811
     """Test if listing all object IDs for a bucket works correctly."""
     file_fixture2 = tmp_file.model_copy(deep=True)
@@ -230,13 +241,24 @@ async def test_handling_non_existing_file_and_bucket(
             object_id=non_existing_object_id,
         )
 
+    # deleting a non-existing object in an existing bucket succeeds silently:
+    await s3.storage.delete_object(
+        bucket_id=existing_bucket_id,
+        object_id=non_existing_object_id,
+    )
+
+    with pytest.raises(ObjectStorageProtocol.BucketNotFoundError):
+        await s3.storage.list_all_object_ids(bucket_id=non_existing_bucket_id)
+
+    # the destination object must not exist in the copy scenarios below, since the
+    # destination check runs before the source is inspected:
     with pytest.raises(ObjectStorageProtocol.BucketNotFoundError):
         # copy when source bucket does not exist:
         await s3.storage.copy_object(
             source_bucket_id=non_existing_bucket_id,
             source_object_id=non_existing_object_id,
             dest_bucket_id=existing_bucket_id,
-            dest_object_id=existing_object_id,
+            dest_object_id=non_existing_object_id,
         )
 
     with pytest.raises(ObjectStorageProtocol.ObjectNotFoundError):
@@ -245,7 +267,7 @@ async def test_handling_non_existing_file_and_bucket(
             source_bucket_id=existing_bucket_id,
             source_object_id=non_existing_object_id,
             dest_bucket_id=existing_bucket_id,
-            dest_object_id=existing_object_id,
+            dest_object_id=non_existing_object_id,
         )
 
     with pytest.raises(ObjectStorageProtocol.BucketNotFoundError):
@@ -260,6 +282,21 @@ async def test_handling_non_existing_file_and_bucket(
     with pytest.raises(ObjectStorageProtocol.ObjectNotFoundError):
         await s3.storage.get_object_size(
             bucket_id=existing_bucket_id, object_id=non_existing_object_id
+        )
+
+    with pytest.raises(ObjectStorageProtocol.BucketNotFoundError):
+        await s3.storage.get_object_size(
+            bucket_id=non_existing_bucket_id, object_id=non_existing_object_id
+        )
+
+    with pytest.raises(ObjectStorageProtocol.ObjectNotFoundError):
+        await s3.storage.get_object_metadata(
+            bucket_id=existing_bucket_id, object_id=non_existing_object_id
+        )
+
+    with pytest.raises(ObjectStorageProtocol.BucketNotFoundError):
+        await s3.storage.get_object_metadata(
+            bucket_id=non_existing_bucket_id, object_id=non_existing_object_id
         )
 
     with pytest.raises(ObjectStorageProtocol.ObjectNotFoundError):

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -267,11 +267,6 @@ async def test_handling_non_existing_file_and_bucket(
             bucket_id=existing_bucket_id, object_id=non_existing_object_id
         )
 
-    with pytest.raises(ObjectStorageProtocol.ObjectNotFoundError):
-        await s3.storage.delete_object(
-            bucket_id=existing_bucket_id, object_id=non_existing_object_id
-        )
-
 
 @pytest.mark.parametrize("delete_content", (True, False))
 async def test_delete_non_empty_bucket(

--- a/tests/integration/providers/objstorage/test_s3_objstorage.py
+++ b/tests/integration/providers/objstorage/test_s3_objstorage.py
@@ -730,7 +730,7 @@ async def test_prefix_filter_ignores_sibling_object_ids(s3: S3Fixture):
     )
     assert uploads == [long_upload_id]
 
-    # The upload check should still find the upload despite the prefix-sharing sibling.
+    # Ensure this also doesn't raise MultipleActiveUploadsError.
     url = await s3.storage.get_part_upload_url(
         upload_id=short_upload_id,
         bucket_id=bucket_id,
@@ -827,8 +827,27 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
         Bucket=bucket_id, Key=object_id
     )["UploadId"]
 
-    # uploading a part and completing the upload both target an explicit
-    # upload_id, so they keep working while a sibling upload is active:
+    # try to work on both uploads:
+    for upload_id in [upload1_id, upload2_id]:
+        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
+            await s3.storage.get_part_upload_url(
+                upload_id=upload_id,
+                bucket_id=bucket_id,
+                object_id=object_id,
+                part_number=1,
+            )
+
+        with pytest.raises(ObjectStorageProtocol.MultipleActiveUploadsError):
+            await s3.storage.complete_multipart_upload(
+                upload_id=upload_id, bucket_id=bucket_id, object_id=object_id
+            )
+
+    # aborting should work:
+    await s3.storage.abort_multipart_upload(
+        upload_id=upload2_id, bucket_id=bucket_id, object_id=object_id
+    )
+
+    # confirm that aborting one upload fixes the problem
     await upload_part(
         s3.storage,
         upload_id=upload1_id,
@@ -839,11 +858,6 @@ async def test_handling_multiple_coexisting_uploads(s3: S3Fixture):
     )
     await s3.storage.complete_multipart_upload(
         upload_id=upload1_id, bucket_id=bucket_id, object_id=object_id
-    )
-
-    # the other upload is left dangling and must be cleaned up explicitly
-    await s3.storage.abort_multipart_upload(
-        upload_id=upload2_id, bucket_id=bucket_id, object_id=object_id
     )
 
 

--- a/tests/unit/test_in_mem_objstorage.py
+++ b/tests/unit/test_in_mem_objstorage.py
@@ -61,6 +61,11 @@ async def test_does_object_exist():
 async def test_delete_object():
     """Test deleting an object"""
     storage = InMemObjectStorage()
+
+    # Try to delete an object in a non-existent bucket - should raise an error
+    with pytest.raises(InMemObjectStorage.BucketNotFoundError):
+        await storage.delete_object(bucket_id=BUCKET1, object_id=OBJECT1)
+
     await storage.create_bucket(bucket_id=BUCKET1)
 
     # Try to delete non-existent object - should NOT raise an error
@@ -414,6 +419,23 @@ async def test_get_object_size():
     storage.buckets[BUCKET1].add(OBJECT1)
     size = await storage.get_object_size(bucket_id=BUCKET1, object_id=OBJECT1)
     assert size == 1024
+
+
+async def test_get_object_metadata():
+    """Test the `.get_object_metadata()` method"""
+    storage = InMemObjectStorage()
+    with pytest.raises(InMemObjectStorage.BucketNotFoundError):
+        await storage.get_object_metadata(bucket_id=BUCKET1, object_id=OBJECT1)
+
+    # Create bucket and expect ObjectNotFoundError
+    await storage.create_bucket(bucket_id=BUCKET1)
+    with pytest.raises(InMemObjectStorage.ObjectNotFoundError):
+        await storage.get_object_metadata(bucket_id=BUCKET1, object_id=OBJECT1)
+
+    # Add object and test for success
+    storage.buckets[BUCKET1].add(OBJECT1)
+    metadata = await storage.get_object_metadata(bucket_id=BUCKET1, object_id=OBJECT1)
+    assert metadata == {"ContentLength": 1024, "ETag": f"etag_for_{OBJECT1}"}
 
 
 async def test_copy_object():

--- a/tests/unit/test_in_mem_objstorage.py
+++ b/tests/unit/test_in_mem_objstorage.py
@@ -63,9 +63,8 @@ async def test_delete_object():
     storage = InMemObjectStorage()
     await storage.create_bucket(bucket_id=BUCKET1)
 
-    # Try to delete non-existent object - should raise error
-    with pytest.raises(InMemObjectStorage.ObjectNotFoundError):
-        await storage.delete_object(bucket_id=BUCKET1, object_id=OBJECT1)
+    # Try to delete non-existent object - should NOT raise an error
+    await storage.delete_object(bucket_id=BUCKET1, object_id=OBJECT1)
 
     # Manually add object and then delete it
     storage.buckets[BUCKET1].add(OBJECT1)


### PR DESCRIPTION
Re-evaluated every S3 provider operation and removed defensive existence checks where the main S3 call already fails with a translatable error.

Removed prechecks

- `delete_bucket` and `list_all_object_ids` rely on `NoSuchBucket`
- `list_parts`, `abort_multipart_upload`, and `complete_multipart_upload` rely on `NoSuchUpload`
- `get_object_etag`/`get_object_size`/`get_object_metadata` rely on `head_object` failing

Optimized

- `_assert_object_(not_)exists` now checks the object first and only checks the bus one call instead of two

Kept (with comments explaining why)

- `create_bucket` - S3 silently succeeds re-creating an owned bucket, so we let the app handle that error
- Presigned URL ops - signing is local, nothing server-side would raise if the upload/bucket didn't exist
- `init_multipart_upload` - to prevent duplicate uploads 
- `delete_object` - so the application decides how to interpret missing objects
- `copy_object` dest check - to prevent overwriting things by accident

### Note for near future

We should consider removing `MultipleActiveUploadsError`. The built-in check for multiple active uploads doesn't give us much. The methods already target specific uploads via `upload_id`, and if an application needs enforce upload exclusivity then that should be done application-side. That would mandate a major version bump though.

Version bumped to `8.5.0`