### PR TITLE
DB Version Check Helper (GSI-2456)

### DIFF
--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -21,6 +21,7 @@ exist and that they are up to date.
 
 import argparse
 import re
+import subprocess
 import sys
 from datetime import date
 from pathlib import Path
@@ -31,75 +32,72 @@ ROOT_DIR = Path(__file__).parent.parent.resolve()
 # file containing the default global copyright notice:
 GLOBAL_COPYRIGHT_FILE_PATH = ROOT_DIR / ".devcontainer" / "license_header.txt"
 
-# exclude files and dirs from license header check:
+# exclude files and dirs from license header check.
+# Note: files ignored by git (see the top-level .gitignore) are excluded
+# automatically, so only tracked files that need exempting are listed here.
 EXCLUDE = [
     ".coveragerc",
     ".devcontainer",
     ".dockerignore",
     ".editorconfig",
-    ".eggs",
     ".git",
     ".github",
     ".flake8",
     ".gitignore",
-    ".mypy_cache",
     ".mypy.ini",
     ".pylintrc",
-    ".pytest_cache",
     ".ruff.toml",
-    ".ruff_cache",
     ".template/.static_files.txt",
     ".template/.static_files_ignore.txt",
     ".template/.mandatory_files.txt",
     ".template/.mandatory_files_ignore.txt",
     ".template/.deprecated_files.txt",
     ".template/.deprecated_files_ignore.txt",
-    ".tox",
-    ".venv",
-    ".vscode",
-    "eggs",
-    "build",
     "config_schema.json",
-    "dist",
     "docs",
-    "develop-eggs",
     "example_config.yaml",
-    "htmlcov",
-    "lib",
-    "lib62",
-    "parts",
-    "pip-wheel-metadata",
-    "sdist",
-    "venv",
-    "wheels",
     "LICENSE",  # is checked but not for the license header
 ]
 
 # exclude file by file ending from license header check:
 EXCLUDE_ENDINGS = [
+    "csv",
+    "fastq",
+    "gif",
+    "gz",
     "html",
+    "ico",
     "in",
     "ini",
+    "ipynb",
     "jinja",
+    "jpeg",
+    "jpg",
     "json",
+    "lock",
     "md",
+    "pdf",
+    "png",
     "pub",
     "pyc",
     "pyd",
-    "typed",
+    "rst",
     "sec",
+    "svg",
+    "tag",
     "toml",
+    "tsv",
     "txt",
+    "typed",
     "xml",
     "yaml",
     "yml",
-    "tsv",
-    "fastq",
-    "gz",
+    "zip",
 ]
 
-# exclude any files with names that match any of the following regex:
-EXCLUDE_PATTERN = [r".*\.egg-info.*", r".*__cache__.*", r".*\.git.*"]
+# exclude any files with names that match any of the following regex
+# (the .git directory itself is not reported by `git check-ignore`):
+EXCLUDE_PATTERN = [r".*\.git.*"]
 
 # The License header, "{year}" will be replaced by current year:
 COPYRIGHT_TEMPLATE = """Copyright {year} {author}
@@ -172,6 +170,43 @@ class UnexpectedBinaryFileError(RuntimeError):
         super().__init__(message)
 
 
+def get_gitignored_files(target_dir: Path, files: list[Path]) -> set[Path]:
+    """Determine which of the given files are ignored by git.
+
+    This uses `git check-ignore` so that the entries of the top-level
+    `.gitignore` (as well as any nested `.gitignore` files, global excludes and
+    `.git/info/exclude`) do not need to be duplicated in `EXCLUDE`.
+
+    Returns an empty set if `target_dir` is not a git repository or git is not
+    available, in which case only the explicit `EXCLUDE` rules take effect.
+    """
+    if not files:
+        return set()
+
+    # feed the paths relative to the repo root on stdin (one per line):
+    rel_paths = [file_.relative_to(target_dir).as_posix() for file_ in files]
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target_dir), "check-ignore", "--stdin"],
+            input="\n".join(rel_paths),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        # git executable not available: fall back to the explicit EXCLUDE rules.
+        return set()
+
+    # exit code 0: some paths are ignored, 1: none are ignored,
+    # anything else (e.g. 128): an error such as "not a git repository".
+    if result.returncode not in (0, 1):
+        return set()
+
+    # git echoes back the same relative paths that it considers ignored:
+    return {target_dir / line for line in result.stdout.splitlines() if line}
+
+
 def get_target_files(
     target_dir: Path,
     exclude: list[str] = EXCLUDE,
@@ -179,6 +214,10 @@ def get_target_files(
     exclude_pattern: list[str] = EXCLUDE_PATTERN,
 ) -> list[Path]:
     """Get target files that are not match the exclude conditions.
+
+    Files ignored by git (see `get_gitignored_files`) are excluded in addition
+    to the explicit exclude conditions below.
+
     Args:
         target_dir (pathlib.Path): The target dir to search.
         exclude (list[str], optional):
@@ -199,10 +238,14 @@ def get_target_files(
         file_.absolute() for file_ in Path(abs_target_dir).rglob("*") if file_.is_file()
     ]
 
+    # files that are ignored by git are excluded automatically:
+    gitignored = get_gitignored_files(abs_target_dir, all_files)
+
     return [
         file_
         for file_ in all_files
-        if not (
+        if file_ not in gitignored
+        and not (
             any(file_.is_relative_to(excl) for excl in exclude_normalized)
             or any(str(file_).endswith(ending) for ending in exclude_endings)
             or any(re.match(pattern, str(file_)) for pattern in exclude_pattern)

--- a/src/hexkit/providers/mongodb/migrations/__init__.py
+++ b/src/hexkit/providers/mongodb/migrations/__init__.py
@@ -21,14 +21,17 @@ from ._manager import (
     MigrationStepError,
 )
 from ._utils import (
+    DbVersionMismatchError,
     Document,
     MigrationConfig,
     MigrationDefinition,
     Reversible,
+    check_db_version,
     validate_doc,
 )
 
 __all__ = [
+    "DbVersionMismatchError",
     "Document",
     "MigrationConfig",
     "MigrationDefinition",
@@ -36,5 +39,6 @@ __all__ = [
     "MigrationMap",
     "MigrationStepError",
     "Reversible",
+    "check_db_version",
     "validate_doc",
 ]

--- a/src/hexkit/providers/mongodb/migrations/__init__.py
+++ b/src/hexkit/providers/mongodb/migrations/__init__.py
@@ -16,12 +16,17 @@
 """Database migration tools for MongoDB"""
 
 from ._manager import (
-    MigrationConfig,
     MigrationManager,
     MigrationMap,
     MigrationStepError,
 )
-from ._utils import Document, MigrationDefinition, Reversible, validate_doc
+from ._utils import (
+    Document,
+    MigrationConfig,
+    MigrationDefinition,
+    Reversible,
+    validate_doc,
+)
 
 __all__ = [
     "Document",

--- a/src/hexkit/providers/mongodb/migrations/_manager.py
+++ b/src/hexkit/providers/mongodb/migrations/_manager.py
@@ -33,6 +33,7 @@ from ._utils import (
     MigrationConfig,
     MigrationDefinition,
     Reversible,
+    _fetch_version_docs,
     _get_db_version_from_records,
 )
 
@@ -156,12 +157,7 @@ class MigrationManager:
     async def _get_version_docs(self) -> list[DbVersionRecord]:
         """Gets the DB version information from the database."""
         collection = self.db[self.config.db_version_collection]
-        # use a filter to avoid picking up the lock doc, just in case
-        version_docs = []
-        async for doc in collection.find({"_id": {"$ne": 0}}):
-            doc.pop("_id")
-            version_docs.append(DbVersionRecord(**doc))  # type: ignore
-        return version_docs
+        return await _fetch_version_docs(collection)
 
     @asynccontextmanager
     async def _lock_db(self):

--- a/src/hexkit/providers/mongodb/migrations/_manager.py
+++ b/src/hexkit/providers/mongodb/migrations/_manager.py
@@ -20,17 +20,21 @@ from collections.abc import Mapping
 from contextlib import asynccontextmanager, suppress
 from datetime import datetime, timezone
 from time import perf_counter, time
-from typing import Literal, TypedDict
+from typing import Literal
 
-from pydantic import Field
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.errors import DuplicateKeyError
 
-from hexkit.providers.mongodb.config import MongoDbConfig
 from hexkit.providers.mongodb.provider import ConfiguredMongoClient
 
-from ._utils import MigrationDefinition, Reversible
+from ._utils import (
+    DbVersionRecord,
+    MigrationConfig,
+    MigrationDefinition,
+    Reversible,
+    _get_db_version_from_records,
+)
 
 log = logging.getLogger(__name__)
 
@@ -46,36 +50,6 @@ def now_as_utc() -> datetime:
 def duration_in_ms(duration: float) -> int:
     """Returns the duration (seconds) expressed as milliseconds"""
     return int(duration * 1000)
-
-
-class MigrationConfig(MongoDbConfig):
-    """Minimal configuration required to run the migration process."""
-
-    db_version_collection: str = Field(
-        ...,
-        description="The name of the collection containing DB version information for this service",
-        examples=["ifrsDbVersions"],
-    )
-    migration_wait_sec: int = Field(
-        ...,
-        description="The number of seconds to wait before checking the DB version again",
-        examples=[5, 30, 180],
-    )
-    migration_max_wait_sec: int | None = Field(
-        default=None,
-        description="The maximum number of seconds to wait for migrations to complete"
-        + " before raising an error.",
-        examples=[None, 300, 600, 3600],
-    )
-
-
-class DbVersionRecord(TypedDict):
-    """Model containing information about DB versions and how they were achieved."""
-
-    version: int
-    completed: datetime
-    backward: bool
-    total_duration_ms: int
 
 
 class MigrationStepError(RuntimeError):
@@ -111,16 +85,6 @@ class MigrationTimeoutError(RuntimeError):
     def __init__(self, *, limit: int):
         msg = f"Timeout occurred - migration duration exceeded {limit} seconds."
         super().__init__(msg)
-
-
-def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
-    """Gets the current DB version from the documents found in the version collection."""
-    # Make sure we know what the latest version is, not just the max
-    return max(
-        version_docs,
-        key=lambda doc: (doc["completed"], doc["version"]),
-        default={"version": 0},
-    )["version"]
 
 
 class MigrationManager:

--- a/src/hexkit/providers/mongodb/migrations/_utils.py
+++ b/src/hexkit/providers/mongodb/migrations/_utils.py
@@ -26,7 +26,11 @@ from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.database import AsyncDatabase
 
 from hexkit.providers.mongodb.config import MongoDbConfig
-from hexkit.providers.mongodb.provider import document_to_dto, dto_to_document
+from hexkit.providers.mongodb.provider import (
+    ConfiguredMongoClient,
+    document_to_dto,
+    dto_to_document,
+)
 
 log = logging.getLogger(__name__)
 
@@ -63,6 +67,17 @@ class DbVersionRecord(TypedDict):
     total_duration_ms: int
 
 
+class DbVersionMismatchError(RuntimeError):
+    """Raised when the database is not at the version expected by the service."""
+
+    def __init__(self, *, db_version: int, target_version: int):
+        msg = (
+            f"Database version is {db_version}, but the service expects version"
+            + f" {target_version}. Make sure migrations have been applied."
+        )
+        super().__init__(msg)
+
+
 def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
     """Gets the current DB version from the documents found in the version collection."""
     # Make sure we know what the latest version is, not just the max
@@ -83,6 +98,25 @@ async def _fetch_version_docs(collection: AsyncCollection) -> list[DbVersionReco
         doc.pop("_id")
         version_docs.append(DbVersionRecord(**doc))  # type: ignore
     return version_docs
+
+
+async def check_db_version(*, config: MigrationConfig, target_version: int) -> None:
+    """Verify that the database is at `target_version`, raising an error if not.
+
+    This function can be used to verify DB state separately from the core migration logic.
+
+    Raises:
+    - `DbVersionMismatchError`: If the current DB version doesn't match `target_version`.
+    """
+    async with ConfiguredMongoClient(config=config) as client:
+        collection = client[config.db_name][config.db_version_collection]
+        version_docs = await _fetch_version_docs(collection)
+
+    db_version = _get_db_version_from_records(version_docs)
+    if db_version != target_version:
+        raise DbVersionMismatchError(
+            db_version=db_version, target_version=target_version
+        )
 
 
 def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):

--- a/src/hexkit/providers/mongodb/migrations/_utils.py
+++ b/src/hexkit/providers/mongodb/migrations/_utils.py
@@ -73,7 +73,7 @@ class DbVersionMismatchError(RuntimeError):
     def __init__(self, *, db_version: int, target_version: int):
         msg = (
             f"Database version is {db_version}, but the service expects version"
-            + f" {target_version}. Make sure migrations have been applied."
+            + f" {target_version}."
         )
         super().__init__(msg)
 

--- a/src/hexkit/providers/mongodb/migrations/_utils.py
+++ b/src/hexkit/providers/mongodb/migrations/_utils.py
@@ -18,16 +18,58 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import Any
+from datetime import datetime
+from typing import Any, TypedDict
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pymongo.asynchronous.database import AsyncDatabase
 
+from hexkit.providers.mongodb.config import MongoDbConfig
 from hexkit.providers.mongodb.provider import document_to_dto, dto_to_document
 
 log = logging.getLogger(__name__)
 
 Document = dict[str, Any]
+
+
+class MigrationConfig(MongoDbConfig):
+    """Minimal configuration required to run the migration process."""
+
+    db_version_collection: str = Field(
+        ...,
+        description="The name of the collection containing DB version information for this service",
+        examples=["ifrsDbVersions"],
+    )
+    migration_wait_sec: int = Field(
+        ...,
+        description="The number of seconds to wait before checking the DB version again",
+        examples=[5, 30, 180],
+    )
+    migration_max_wait_sec: int | None = Field(
+        default=None,
+        description="The maximum number of seconds to wait for migrations to complete"
+        + " before raising an error.",
+        examples=[None, 300, 600, 3600],
+    )
+
+
+class DbVersionRecord(TypedDict):
+    """Model containing information about DB versions and how they were achieved."""
+
+    version: int
+    completed: datetime
+    backward: bool
+    total_duration_ms: int
+
+
+def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
+    """Gets the current DB version from the documents found in the version collection."""
+    # Make sure we know what the latest version is, not just the max
+    return max(
+        version_docs,
+        key=lambda doc: (doc["completed"], doc["version"]),
+        default={"version": 0},
+    )["version"]
 
 
 def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):

--- a/src/hexkit/providers/mongodb/migrations/_utils.py
+++ b/src/hexkit/providers/mongodb/migrations/_utils.py
@@ -22,6 +22,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from pydantic import BaseModel, Field
+from pymongo.asynchronous.collection import AsyncCollection
 from pymongo.asynchronous.database import AsyncDatabase
 
 from hexkit.providers.mongodb.config import MongoDbConfig
@@ -70,6 +71,18 @@ def _get_db_version_from_records(version_docs: list[DbVersionRecord]) -> int:
         key=lambda doc: (doc["completed"], doc["version"]),
         default={"version": 0},
     )["version"]
+
+
+async def _fetch_version_docs(collection: AsyncCollection) -> list[DbVersionRecord]:
+    """Fetch the DB version records from the version collection.
+
+    The lock document (`_id: 0`) is excluded.
+    """
+    version_docs = []
+    async for doc in collection.find({"_id": {"$ne": 0}}):
+        doc.pop("_id")
+        version_docs.append(DbVersionRecord(**doc))  # type: ignore
+    return version_docs
 
 
 def validate_doc(doc: Document, *, model: type[BaseModel], id_field: str):

--- a/tests/integration/migrations/test_mongodb_migrations.py
+++ b/tests/integration/migrations/test_mongodb_migrations.py
@@ -664,10 +664,16 @@ async def test_check_db_version_mismatch(mongodb: MongoDbFixture):
     with pytest.raises(DbVersionMismatchError):
         await check_db_version(config=config, target_version=2)
 
+    # Run a migration to get the DB to version 2
     migration_map = {2: V2BasicMigration}
     await run_db_migrations(
         config=config, target_version=2, migration_map=migration_map
     )
 
+    # Make sure we get an error if DB is behind
     with pytest.raises(DbVersionMismatchError):
         await check_db_version(config=config, target_version=3)
+
+    # Make sure we also get an error if the DB is ahead
+    with pytest.raises(DbVersionMismatchError):
+        await check_db_version(config=config, target_version=1)

--- a/tests/integration/migrations/test_mongodb_migrations.py
+++ b/tests/integration/migrations/test_mongodb_migrations.py
@@ -27,12 +27,14 @@ from pymongo.collection import Collection
 
 from hexkit.providers.mongodb import MongoDbConfig
 from hexkit.providers.mongodb.migrations import (
+    DbVersionMismatchError,
     MigrationConfig,
     MigrationDefinition,
     MigrationManager,
     MigrationMap,
     MigrationStepError,
     Reversible,
+    check_db_version,
 )
 from hexkit.providers.mongodb.migrations._manager import MigrationTimeoutError
 from hexkit.providers.mongodb.provider import ConfiguredMongoClient
@@ -637,3 +639,35 @@ async def test_version_in_backwards_migration_error(mongodb: MongoDbFixture):
             config=config, target_version=1, migration_map=migration_map
         )
     assert err.value.args[0] == msg
+
+
+async def test_check_db_version_up_to_date(mongodb: MongoDbFixture):
+    """Ensure check_db_version doesn't raise when the DB is already at the target version."""
+    config = make_migration_config(mongodb.config)
+    migration_map = {2: V2BasicMigration}
+    await run_db_migrations(
+        config=config, target_version=2, migration_map=migration_map
+    )
+
+    await check_db_version(config=config, target_version=2)
+
+
+async def test_check_db_version_mismatch(mongodb: MongoDbFixture):
+    """Ensure that check_db_version raises DbVersionMismatchError when versions differ.
+
+    Covers both an uninitialized DB (no version records at all) and a DB that has
+    been migrated but not to the version the caller expects.
+    """
+    config = make_migration_config(mongodb.config)
+
+    # No migrations have been run yet, so the recorded version is effectively 0
+    with pytest.raises(DbVersionMismatchError):
+        await check_db_version(config=config, target_version=2)
+
+    migration_map = {2: V2BasicMigration}
+    await run_db_migrations(
+        config=config, target_version=2, migration_map=migration_map
+    )
+
+    with pytest.raises(DbVersionMismatchError):
+        await check_db_version(config=config, target_version=3)


### PR DESCRIPTION
This introduces a `check_db_version()` utility for the migration tools. Its purpose is to provide a convenient way to enforce DB state in application code independent of the checks that occur in migrations themselves.